### PR TITLE
SSH key tweaks

### DIFF
--- a/lib/kitchen/driver/openstack.rb
+++ b/lib/kitchen/driver/openstack.rb
@@ -136,6 +136,9 @@ module Kitchen
 
       def check_ssh_key(state, config, server, ignore_errors)
         opts = {}
+        if server.password
+          opts[:password] = server.password
+        end
         if File.exists?(config[:private_key_path])
           opts = { :key_data => open(config[:private_key_path]).read }
         end


### PR DESCRIPTION
The test image I was using does not come with a password, and instead relies on Openstack's keypair support. This code will import a keypair and add it to the image via the Openstack API.
