### PR TITLE
Fix #16 and #17 - Rewrite get_ip method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # ?.?.? / ????-??-??
 
+### Improvements
+
+* PR [#19][] - Don't assume `public` and `private` network names exist
+* PR [#19][] - Make IPv4 or IPv6 configurable instead of relying on Fog to pick
+
 # 0.4.0 / 2013-06-06
 
 ### New Features
@@ -27,6 +32,7 @@
 
 * Initial release! Woo!
 
+[#19]: https://github.com/RoboticCheese/kitchen-openstack/pull/19
 [#12]: https://github.com/RoboticCheese/kitchen-openstack/pull/12
 [#11]: https://github.com/RoboticCheese/kitchen-openstack/pull/11
 [#10]: https://github.com/RoboticCheese/kitchen-openstack/pull/10

--- a/kitchen-openstack.gemspec
+++ b/kitchen-openstack.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'test-kitchen', '~> 1.0.0.alpha'
-  spec.add_dependency 'fog', '~> 1.11'
+  spec.add_dependency 'test-kitchen', '~> 1.0.0.beta'
+  spec.add_dependency 'fog', '~> 1.15'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
- Bump dep version of Fog
- Not all OpenStack deployments use the `public` and `private` network
  names. Start by trying the `public_ip_addresses` and
  `public_ip_addresses` methods.
- If those methods aren't supported (Fog issue with OpenStack systems
  without floating IPs), only then resort to trying to parse the
  `addresses` hash.
- Ordering of those IPs isn't guaranteed, which would result in
  sometimes getting a v6 IP even if you have no way to access it.
