### PR TITLE
Allow to specify networks to which NICs will be connected when creating VM

### DIFF
--- a/lib/kitchen/driver/openstack.rb
+++ b/lib/kitchen/driver/openstack.rb
@@ -52,6 +52,7 @@ module Kitchen
       default_config :floating_ip_pool, nil
       default_config :floating_ip, nil
       default_config :security_groups, nil
+      default_config :nics, nil
 
       def create(state)
         config[:server_name] ||= generate_name(instance.name)
@@ -128,6 +129,9 @@ module Kitchen
         end
         if config[:public_key_path]
           server_def[:public_key_path] = config[:public_key_path]
+        end
+        if config[:nics] && config[:nics].kind_of?(Array)
+          server_def[:nics] = config[:nics]
         end
         server_def[:key_name] = config[:key_name] if config[:key_name]
         # Can't use the Fog bootstrap and/or setup methods here; they require a


### PR DESCRIPTION
This allows to specify networks to which VM will be connected, when the openstack has multiple networks.
This is passed to the attribute "networks" in create server request.
This will work fine on fog the commit https://github.com/fog/fog/commit/9938c92516a4e82d092f54f8982cf4ed6f2cc250 or later.
