### PR TITLE
Use floating IP for ssh connection by default if defined or allocated from pool.

### DIFF
--- a/lib/kitchen/driver/openstack.rb
+++ b/lib/kitchen/driver/openstack.rb
@@ -218,8 +218,8 @@ module Kitchen
           if free_addrs.empty?
             raise ActionFailed, "No available IPs in pool <#{pool}>"
           end
-          attach_ip(server, free_addrs[0])
           config[:floating_ip] = free_addrs[0]
+          attach_ip(server, free_addrs[0])
         end
       end
 


### PR DESCRIPTION
In my opinion, if you go to the trouble of allocating a floating IP, you probably want to use it to connect with SSH. This patch implements that functionality. 
