### PR TITLE
Add OpenStack Ohai hints file

### DIFF
--- a/kitchen-openstack.gemspec
+++ b/kitchen-openstack.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'fog', '~> 1.18'
   # Newer Fogs throw a warning if unf isn't there :(
   spec.add_dependency 'unf'
+  spec.add_dependency 'ohai'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'

--- a/lib/kitchen/driver/openstack.rb
+++ b/lib/kitchen/driver/openstack.rb
@@ -22,6 +22,7 @@ require 'kitchen'
 require 'etc'
 require 'ipaddr'
 require 'socket'
+require 'ohai'
 
 module Kitchen
   module Driver
@@ -265,8 +266,8 @@ module Kitchen
         info 'Adding OpenStack hint for ohai'
         ssh = Fog::SSH.new(*build_ssh_args(state))
         ssh.run([
-          %{sudo mkdir -p /etc/chef/ohai/hints},
-          %{sudo touch /etc/chef/ohai/hints/openstack.json}
+          %{sudo mkdir -p #{Ohai::Config[:hints_path][0]}},
+          %{sudo touch #{Ohai::Config[:hints_path][0]}/openstack.json}
         ])
       end
 

--- a/spec/kitchen/driver/openstack_spec.rb
+++ b/spec/kitchen/driver/openstack_spec.rb
@@ -22,6 +22,7 @@ require 'logger'
 require 'stringio'
 require 'rspec'
 require 'kitchen'
+require 'ohai'
 
 describe Kitchen::Driver::Openstack do
   let(:logged_output) { StringIO.new }
@@ -904,8 +905,8 @@ describe Kitchen::Driver::Openstack do
         anything()).and_return(ssh)
       res = driver.send(:add_ohai_hint, state, config, server)
       expected = [
-        'sudo mkdir -p /etc/chef/ohai/hints',
-        'sudo touch /etc/chef/ohai/hints/openstack.json'
+        "sudo mkdir -p #{Ohai::Config[:hints_path][0]}",
+        "sudo touch #{Ohai::Config[:hints_path][0]}/openstack.json"
       ]
       expect(res).to eq(expected)
     end


### PR DESCRIPTION
Adds an empty file to (typically) `/etc/chef/ohai/hints/openstack.json` so the openstack ohai plugin does its thing and populates node['openstack'] attributes. 
