### PR TITLE
Fix #54; prevent errors on non-login shells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ?.?.? / ????.??.??
 
+### Bug Fixes
+
+* PR [#58][] - Prevent errors when run without a login shell
+
 # 1.5.3 / 2014-08-01
 
 * PR [#53][] - Rework how server names are generated, disallowing possibly
@@ -108,6 +112,7 @@ certain specified NICs; via [@monsterzz][]
 
 * Initial release! Woo!
 
+[#58]: https://github.com/test-kitchen/kitchen-openstack/pull/58
 [#53]: https://github.com/test-kitchen/kitchen-openstack/pull/53
 [#50]: https://github.com/test-kitchen/kitchen-openstack/pull/50
 [#49]: https://github.com/test-kitchen/kitchen-openstack/pull/49

--- a/lib/kitchen/driver/openstack.rb
+++ b/lib/kitchen/driver/openstack.rb
@@ -192,7 +192,7 @@ module Kitchen
       def default_name
         [
           instance.name.gsub(/\W/, '')[0..14],
-          Etc.getlogin.gsub(/\W/, '')[0..14],
+          (Etc.getlogin || 'nologin').gsub(/\W/, '')[0..14],
           Socket.gethostname.gsub(/\W/, '')[0..22],
           Array.new(7) { rand(36).to_s(36) }.join
         ].join('-')

--- a/spec/kitchen/driver/openstack_spec.rb
+++ b/spec/kitchen/driver/openstack_spec.rb
@@ -669,6 +669,14 @@ describe Kitchen::Driver::Openstack do
         expect(driver.send(:default_name).count('-')).to eq(3)
       end
     end
+
+    context 'a non-login shell' do
+      let(:login) { nil }
+
+      it 'subs in a placeholder login string' do
+        expect(driver.send(:default_name)).to match(/^potatoes-nologin-/)
+      end
+    end
   end
 
   describe '#attach_ip_from_pool' do


### PR DESCRIPTION
Also copies over name generator updates from kitchen-digitalocean.
