### PR TITLE
add availability_zone support

### DIFF
--- a/lib/kitchen/driver/openstack.rb
+++ b/lib/kitchen/driver/openstack.rb
@@ -147,7 +147,7 @@ module Kitchen
           image_ref: find_image(config[:image_ref]).id,
           flavor_ref: find_flavor(config[:flavor_ref]).id
         }
-        if config.has_key? :availability_zone
+        if config.key? :availability_zone
           init_conf[:availability_zone] = config[:availability_zone]
         end
         init_conf


### PR DESCRIPTION
this fixing add a availability_zone parameter,
and user could select availability zone as they want.
example .kitchen.yml:

driver:
  name: openstack
  openstack_auth_url: xxxxxxxxxxxxxx
  openstack_username: xxxxxxxxx
  openstack_api_key: xxxxxx
  image_ref: xxxxxxx
  flavor_ref: 1
  server_name: testserver01
  availability_zone: ZONENAME
