### PR TITLE
ssh password support & cmd env support & unique server-name support

### DIFF
--- a/lib/kitchen/driver/openstack.rb
+++ b/lib/kitchen/driver/openstack.rb
@@ -160,14 +160,16 @@ module Kitchen
           end
         end
 
-	keywords = [
+        keywords = [
           :security_groups,
           :public_key_path,
           :key_name,
           :user_data
         ]
-	keywords.each do |c|
-          server_def[c] = optional_config(c) if config[c]
+        keywords.each do |c|
+          if config[c]
+            server_def[c] = optional_config(c)
+          end
         end
 
         # Can't use the Fog bootstrap and/or setup methods here; they require a

--- a/lib/kitchen/driver/openstack.rb
+++ b/lib/kitchen/driver/openstack.rb
@@ -105,7 +105,7 @@ module Kitchen
         # if env is defined, add env terms when execute cmd.
         is_sudo = cmd.start_with?('sudo -E')
         naked_cmd = is_sudo ? cmd[8..-1] : cmd # remove sudo -E
-        env = "env"
+        env = 'env'
         unless config[:env].nil?
           config[:env].each do |env_k, env_v|
             env << " #{env_k}=#{env_v}"

--- a/lib/kitchen/driver/openstack.rb
+++ b/lib/kitchen/driver/openstack.rb
@@ -344,7 +344,7 @@ module Kitchen
 
       def do_ssh_setup(state, config, server)
         info "Setting up SSH access for key <#{config[:public_key_path]}>"
-	password = config[:password].nil? ? server.password : config[:password]
+        password = config[:password].nil? ? server.password : config[:password]
         ssh = Fog::SSH.new(state[:hostname],
                            config[:username],
                            password: password)

--- a/lib/kitchen/driver/openstack.rb
+++ b/lib/kitchen/driver/openstack.rb
@@ -165,16 +165,17 @@ module Kitchen
           :public_key_path,
           :key_name,
           :user_data
-        ]
-        keywords.each do |c|
-          if config[c]
-            server_def[c] = optional_config(c)
-          end
+        ].each do |c|
+          server_def[c] = optional_config(c) if config[c]
         end
 
         # Can't use the Fog bootstrap and/or setup methods here; they require a
         # public IP address that can't be guaranteed to exist across all
         # OpenStack deployments (e.g. TryStack ARM only has private IPs).
+        check_server(server_def)
+      end
+
+      def check_server(server_def)
         compute.servers.each do |server|
           if server.name == server_def[:name]
             puts "Server #{server.name} already exist. Will use it."

--- a/lib/kitchen/driver/openstack.rb
+++ b/lib/kitchen/driver/openstack.rb
@@ -114,11 +114,7 @@ module Kitchen
         if env == 'env'
           cmd
         else
-          if is_sudo
-            "sudo -E #{env} #{naked_cmd}"
-          else
-            "#{env} #{cmd}"
-          end
+          is_sudo ? "sudo -E #{env} #{naked_cmd}" : "#{env} #{cmd}"
         end
       end
 

--- a/lib/kitchen/driver/openstack.rb
+++ b/lib/kitchen/driver/openstack.rb
@@ -176,10 +176,7 @@ module Kitchen
 
       def check_server(server_def)
         compute.servers.each do |server|
-          if server.name == server_def[:name]
-            puts "Server #{server.name} already exist. Will use it."
-            return server
-          end
+          server if server.name == server_def[:name]
         end
         compute.servers.create(server_def)
       end

--- a/lib/kitchen/driver/openstack.rb
+++ b/lib/kitchen/driver/openstack.rb
@@ -160,7 +160,7 @@ module Kitchen
           end
         end
 
-        keywords = [
+        [
           :security_groups,
           :public_key_path,
           :key_name,

--- a/lib/kitchen/driver/openstack.rb
+++ b/lib/kitchen/driver/openstack.rb
@@ -101,6 +101,20 @@ module Kitchen
         state.delete(:hostname)
       end
 
+      def env_cmd(cmd)
+        # if env is defined, add env terms when execute cmd.
+        is_sudo = cmd.start_with?("sudo -E")
+        naked_cmd = is_sudo ? cmd[8..-1] : cmd # remove sudo -E(8 charactors ahead)
+        env = "env"
+        if not config[:env].nil? then
+          config[:env].each do |env_k, env_v|
+            env << " #{env_k}=#{env_v}"
+          end
+        end
+        env == "env" ? cmd : is_sudo ? "sudo -E #{env} #{naked_cmd}" : "#{env} #{cmd}"
+      end
+
+
       private
 
       def openstack_server
@@ -150,6 +164,12 @@ module Kitchen
         # Can't use the Fog bootstrap and/or setup methods here; they require a
         # public IP address that can't be guaranteed to exist across all
         # OpenStack deployments (e.g. TryStack ARM only has private IPs).
+        compute.servers.each do |server|
+          if server.name == server_def[:name]
+            puts "Server #{server.name} already exist. Will use it."
+            return server
+          end
+        end
         compute.servers.create(server_def)
       end
 
@@ -316,9 +336,10 @@ module Kitchen
 
       def do_ssh_setup(state, config, server)
         info "Setting up SSH access for key <#{config[:public_key_path]}>"
+	password = config[:password].nil? ? server.password : config[:password]
         ssh = Fog::SSH.new(state[:hostname],
                            config[:username],
-                           password: server.password)
+                           password: password)
         pub_key = open(config[:public_key_path]).read
         ssh.run([
           %(mkdir .ssh),

--- a/lib/kitchen/driver/openstack.rb
+++ b/lib/kitchen/driver/openstack.rb
@@ -160,12 +160,13 @@ module Kitchen
           end
         end
 
-        [
+	keywords = [
           :security_groups,
           :public_key_path,
           :key_name,
           :user_data
-        ].each do |c|
+        ]
+	keywords.each do |c|
           server_def[c] = optional_config(c) if config[c]
         end
 

--- a/lib/kitchen/driver/openstack.rb
+++ b/lib/kitchen/driver/openstack.rb
@@ -103,15 +103,15 @@ module Kitchen
 
       def env_cmd(cmd)
         # if env is defined, add env terms when execute cmd.
-        is_sudo = cmd.start_with?("sudo -E")
+        is_sudo = cmd.start_with?('sudo -E')
         naked_cmd = is_sudo ? cmd[8..-1] : cmd # remove sudo -E
         env = "env"
-        if not config[:env].nil? then
+        unless config[:env].nil?
           config[:env].each do |env_k, env_v|
             env << " #{env_k}=#{env_v}"
           end
         end
-        if env == "env"
+        if env == 'env'
           cmd
         else
           if is_sudo
@@ -121,7 +121,6 @@ module Kitchen
           end
         end
       end
-
 
       private
 

--- a/lib/kitchen/driver/openstack.rb
+++ b/lib/kitchen/driver/openstack.rb
@@ -104,14 +104,22 @@ module Kitchen
       def env_cmd(cmd)
         # if env is defined, add env terms when execute cmd.
         is_sudo = cmd.start_with?("sudo -E")
-        naked_cmd = is_sudo ? cmd[8..-1] : cmd # remove sudo -E(8 charactors ahead)
+        naked_cmd = is_sudo ? cmd[8..-1] : cmd # remove sudo -E
         env = "env"
         if not config[:env].nil? then
           config[:env].each do |env_k, env_v|
             env << " #{env_k}=#{env_v}"
           end
         end
-        env == "env" ? cmd : is_sudo ? "sudo -E #{env} #{naked_cmd}" : "#{env} #{cmd}"
+        if env == "env"
+          cmd
+        else
+          if is_sudo
+            "sudo -E #{env} #{naked_cmd}"
+          else
+            "#{env} #{cmd}"
+          end
+        end
       end
 
 

--- a/spec/kitchen/driver/openstack_spec.rb
+++ b/spec/kitchen/driver/openstack_spec.rb
@@ -376,6 +376,7 @@ describe Kitchen::Driver::Openstack do
     let(:servers) do
       s = double('servers')
       allow(s).to receive(:create) { |arg| arg }
+      allow(s).to receive(:each) { |arg| arg }
       s
     end
     let(:vlan1_net) { double(id: '1', name: 'vlan1') }


### PR DESCRIPTION
there are three inprovements:

1. support user login use username/password by ssh
2. when command is executed, env can be modified. this is useful when chef is not installed in standard path.
3. server-name unique checking. Now if you want to create a instance but another instance is already existed with same server name, kitchen will skip creating it.

there is a example of .kitchen.yml:

---
driver:
  name: openstack
  openstack_auth_url: xxxxxxxxx
  openstack_username: user01
  openstack_api_key: userpasswd01
  image_ref: xxxxxxxxx
  flavor_ref: 1
  server_name: <THIS IS SERVER NAME>
  username: root
  password: <ROOT PASSWORD>
  env:
    PATH: /usr/local/chef/bin:/bin
