### PR TITLE
OpenStack credentials and connection config can now be overridden by env...

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,27 @@ Or install it yourself as:
 
 ## Usage
 
+The driver needs to be able to connect and authenticate to the OpenStack instance
+you intend to use for testing. You can provide connection and authentication data
+either directly in the the `.kitchen.yml` file OR you can depend on environment
+variables that are commonly setup when using OpenStack CLI tools: 
+http://docs.openstack.org/cli-reference/content/cli_openrc.html
+
+Any configuration within your environment will take precedence over
+values defined in the `.kitchen.yml`
+
+### OpenStack Configuration ENV to YML Mapping
+
+Environment Variable | .kitchen.yml configuration key
+---------------------| ------------------------------
+OS_USERNAME          | openstack_username
+OS_PASSWORD          | openstack_api_key
+OS_AUTH_URL          | openstack_auth_url
+OS_TENANT_NAME       | openstack_tenant
+OS_REGION_NAME       | openstack_region
+
+### Required Configuration
+
 Provide, at a minimum, the required driver options in your `.kitchen.yml` file:
 
     driver:

--- a/lib/kitchen/driver/openstack.rb
+++ b/lib/kitchen/driver/openstack.rb
@@ -110,17 +110,33 @@ module Kitchen
         server_def = {
           provider: 'OpenStack'
         }
-        required_server_settings.each { |s| server_def[s] = config[s] }
-        optional_server_settings.each { |s| server_def[s] = config[s] }
+        server_def.merge!(required_server_settings)
+        server_def.merge!(optional_server_settings)
         server_def
       end
 
       def required_server_settings
-        [:openstack_username, :openstack_api_key, :openstack_auth_url]
+        settings = {}
+        settings[:openstack_username] =
+          ENV['OS_USERNAME'] || config[:openstack_username]
+        settings[:openstack_api_key] =
+          ENV['OS_PASSWORD'] || config[:openstack_api_key]
+        if ENV['OS_AUTH_URL']
+          settings[:openstack_auth_url] = "#{ENV['OS_AUTH_URL']}/tokens"
+        else
+          settings[:openstack_auth_url] = config[:openstack_auth_url]
+        end
+        settings
       end
 
       def optional_server_settings
-        [:openstack_tenant, :openstack_region, :openstack_service_name]
+        settings = {}
+        settings[:openstack_tenant] =
+          ENV['OS_TENANT_NAME'] || config[:openstack_tenant]
+        settings[:openstack_region] =
+          ENV['OS_REGION_NAME'] || config[:openstack_region]
+        settings[:openstack_service_name] = config[:openstack_service_name]
+        settings
       end
 
       def network

--- a/spec/kitchen/driver/openstack_spec.rb
+++ b/spec/kitchen/driver/openstack_spec.rb
@@ -284,7 +284,33 @@ describe Kitchen::Driver::Openstack do
       }
     end
 
-    it 'returns a hash of server settings' do
+    it 'uses ENV values if provided' do
+      ENV['OS_USERNAME'] = 'env_user'
+      ENV['OS_PASSWORD'] = 'env_api_key'
+      ENV['OS_TENANT_NAME'] = 'env_tenant'
+      ENV['OS_REGION_NAME'] = 'env_region'
+      ENV['OS_AUTH_URL'] = 'env_auth_url'
+
+      expected = {
+        openstack_username: 'env_user',
+        openstack_api_key: 'env_api_key',
+        openstack_tenant: 'env_tenant',
+        openstack_region: 'env_region',
+        openstack_auth_url: 'env_auth_url/tokens',
+        openstack_service_name: 'stack',
+        provider: 'OpenStack'
+      }
+
+      expect(driver.send(:openstack_server)).to eq(expected)
+    end
+
+    it 'falls back to yml values if the ENV values are not present' do
+      ENV['OS_USERNAME'] = nil
+      ENV['OS_PASSWORD'] = nil
+      ENV['OS_TENANT_NAME'] = nil
+      ENV['OS_REGION_NAME'] = nil
+      ENV['OS_AUTH_URL'] = nil
+
       expected = config.merge(provider: 'OpenStack')
       expect(driver.send(:openstack_server)).to eq(expected)
     end
@@ -292,19 +318,23 @@ describe Kitchen::Driver::Openstack do
 
   describe '#required_server_settings' do
     it 'returns the required settings for an OpenStack server' do
-      expected = [
+      expected_keys = [
         :openstack_username, :openstack_api_key, :openstack_auth_url
       ]
-      expect(driver.send(:required_server_settings)).to eq(expected)
+      expected_keys.each do |expected|
+        expect(driver.send(:required_server_settings)).to include(expected)
+      end
     end
   end
 
   describe '#optional_server_settings' do
     it 'returns the optional settings for an OpenStack server' do
-      expected = [
+      expected_keys = [
         :openstack_tenant, :openstack_region, :openstack_service_name
       ]
-      expect(driver.send(:optional_server_settings)).to eq(expected)
+      expected_keys.each do |expected|
+        expect(driver.send(:optional_server_settings)).to include(expected)
+      end
     end
   end
 


### PR DESCRIPTION
...ironment variables that are commonly defined by openrch.sh and used by OpenStack CLI tools

The rationale behind this change is to be able to commit .kitchen.yml to source control without it containing user specific details/credentials.