### PR TITLE
Environment variable configuration overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,12 +102,35 @@ generating random names of the form `<NAME PREFIX>-<RANDOM STRING>` e.g.
 `myproject-asdfghjk`. If both `server_name_prefix` and `server_name` are 
 specified then the `server_name` takes precedence.
 
+### Configuring SSH
+
+#### YML configuration
+
 If a `key_name` is provided it will be used instead of any
 `public_key_path` that is specified.
 
 If a `key_name` is provided without any `private_key_path`, unexpected
 behavior may result if your local RSA/DSA private key doesn't match that
 OpenStack key.
+
+#### Environment variable configuration
+
+You may also configure which key pair is used when creating your instance
+and where to find your private key used to ssh to that instance using environment
+variables. This is helpful in cases where multiple users with unique keys are
+collaborating on the tests.
+
+Any configuration within your environment will take precedence over
+values defined in the `.kitchen.yml`
+
+### Configuration ENV to YML Mapping
+
+Environment Variable | .kitchen.yml configuration key
+---------------------| ------------------------------
+OS_KEY_NAME          | key_name
+OS_PRIVATE_KEY_PATH  | private_key_path
+
+### Configuring Networking
 
 A specific `floating_ip` or the ID of a `floating_ip_pool` can be provided to
 bind a floating IP to the node. Any floating IP will be the IP used for

--- a/lib/kitchen/driver/openstack.rb
+++ b/lib/kitchen/driver/openstack.rb
@@ -110,17 +110,33 @@ module Kitchen
         server_def = {
           provider: 'OpenStack'
         }
-        required_server_settings.each { |s| server_def[s] = config[s] }
-        optional_server_settings.each { |s| server_def[s] = config[s] }
+        server_def.merge!(required_server_settings)
+        server_def.merge!(optional_server_settings)
         server_def
       end
 
       def required_server_settings
-        [:openstack_username, :openstack_api_key, :openstack_auth_url]
+        settings = {}
+        settings[:openstack_username] =
+          ENV['OS_USERNAME'] || config[:openstack_username]
+        settings[:openstack_api_key] =
+          ENV['OS_PASSWORD'] || config[:openstack_api_key]
+        if ENV['OS_AUTH_URL']
+          settings[:openstack_auth_url] = "#{ENV['OS_AUTH_URL']}/tokens"
+        else
+          settings[:openstack_auth_url] = config[:openstack_auth_url]
+        end
+        settings
       end
 
       def optional_server_settings
-        [:openstack_tenant, :openstack_region, :openstack_service_name]
+        settings = {}
+        settings[:openstack_tenant] =
+          ENV['OS_TENANT_NAME'] || config[:openstack_tenant]
+        settings[:openstack_region] =
+          ENV['OS_REGION_NAME'] || config[:openstack_region]
+        settings[:openstack_service_name] = config[:openstack_service_name]
+        settings
       end
 
       def network

--- a/lib/kitchen/driver/openstack.rb
+++ b/lib/kitchen/driver/openstack.rb
@@ -334,18 +334,24 @@ module Kitchen
         ])
       end
 
+      def ssh_key_name
+        ENV['OS_KEY_NAME'] || config[:key_name]
+      end
+
+      def ssh_private_key_path
+        ENV['OS_PRIVATE_KEY_PATH'] || config[:private_key_path]
+      end
+
       def setup_ssh(server, state)
         tcp_check(state)
-        if config[:key_name]
-          info "Using OpenStack keypair <#{config[:key_name]}>"
-        end
-        info "Using public SSH key <#{config[:public_key_path]}>"
-        info "Using private SSH key <#{config[:private_key_path]}>"
-        state[:ssh_key] = config[:private_key_path]
-        do_ssh_setup(state, config, server) unless config[:key_name]
+        info "Using OpenStack keypair <#{ssh_key_name}>" if ssh_key_name
+        info "Using private SSH key <#{ssh_private_key_path}>"
+        state[:ssh_key] = ssh_private_key_path
+        do_ssh_setup(state, config, server) unless ssh_key_name
       end
 
       def do_ssh_setup(state, config, server)
+        info "Using public SSH key <#{config[:public_key_path]}>"
         info "Setting up SSH access for key <#{config[:public_key_path]}>"
         ssh = Fog::SSH.new(state[:hostname],
                            config[:username],

--- a/lib/kitchen/driver/openstack.rb
+++ b/lib/kitchen/driver/openstack.rb
@@ -42,9 +42,7 @@ module Kitchen
           f if File.exist?(f)
         end.compact.first
       end
-      default_config :public_key_path do |driver|
-        driver[:private_key_path] + '.pub'
-      end
+      default_config :public_key_path, nil
       default_config :username, 'root'
       default_config :password, nil
       default_config :port, '22'
@@ -169,10 +167,11 @@ module Kitchen
           server_def[:block_device_mapping] = get_bdm(config)
         end
 
+        server_def[:key_name] = ssh_key_name
+        
         [
           :security_groups,
           :public_key_path,
-          :key_name,
           :user_data
         ].each do |c|
           server_def[c] = optional_config(c) if config[c]

--- a/spec/kitchen/driver/openstack_spec.rb
+++ b/spec/kitchen/driver/openstack_spec.rb
@@ -284,7 +284,33 @@ describe Kitchen::Driver::Openstack do
       }
     end
 
-    it 'returns a hash of server settings' do
+    it 'uses ENV values if provided' do
+      ENV['OS_USERNAME'] = 'env_user'
+      ENV['OS_PASSWORD'] = 'env_api_key'
+      ENV['OS_TENANT_NAME'] = 'env_tenant'
+      ENV['OS_REGION_NAME'] = 'env_region'
+      ENV['OS_AUTH_URL'] = 'env_auth_url'
+
+      expected = {
+        openstack_username: 'env_user',
+        openstack_api_key: 'env_api_key',
+        openstack_tenant: 'env_tenant',
+        openstack_region: 'env_region',
+        openstack_auth_url: 'env_auth_url/tokens',
+        openstack_service_name: 'stack',
+        provider: 'OpenStack'
+      }
+
+      expect(driver.send(:openstack_server)).to eq(expected)
+    end
+
+    it 'falls back to yml values if the ENV values are not present' do
+      ENV['OS_USERNAME'] = nil
+      ENV['OS_PASSWORD'] = nil
+      ENV['OS_TENANT_NAME'] = nil
+      ENV['OS_REGION_NAME'] = nil
+      ENV['OS_AUTH_URL'] = nil
+
       expected = config.merge(provider: 'OpenStack')
       expect(driver.send(:openstack_server)).to eq(expected)
     end
@@ -292,19 +318,23 @@ describe Kitchen::Driver::Openstack do
 
   describe '#required_server_settings' do
     it 'returns the required settings for an OpenStack server' do
-      expected = [
+      expected_keys = [
         :openstack_username, :openstack_api_key, :openstack_auth_url
       ]
-      expect(driver.send(:required_server_settings)).to eq(expected)
+      expected_keys.each do |expected|
+        expect(driver.send(:required_server_settings)).to include(expected)
+      end
     end
   end
 
   describe '#optional_server_settings' do
     it 'returns the optional settings for an OpenStack server' do
-      expected = [
+      expected_keys = [
         :openstack_tenant, :openstack_region, :openstack_service_name
       ]
-      expect(driver.send(:optional_server_settings)).to eq(expected)
+      expected_keys.each do |expected|
+        expect(driver.send(:optional_server_settings)).to include(expected)
+      end
     end
   end
 

--- a/spec/kitchen/driver/openstack_spec.rb
+++ b/spec/kitchen/driver/openstack_spec.rb
@@ -1113,6 +1113,34 @@ describe Kitchen::Driver::Openstack do
     end
   end
 
+  describe '#ssh_key_name' do
+    let(:config) { { key_name: 'yml_key_name' } }
+
+    it 'can be overridden using the environment variable OS_KEY_NAME' do
+      ENV['OS_KEY_NAME'] = 'env_key_name'
+      expect(driver.send(:ssh_key_name)).to eq('env_key_name')
+    end
+
+    it 'uses the yml value when no environment variable override is present' do
+      ENV['OS_KEY_NAME'] = nil
+      expect(driver.send(:ssh_key_name)).to eq('yml_key_name')
+    end
+  end
+
+  describe '#ssh_private_key_path' do
+    let(:config) { { private_key_path: 'yml_private_key_path' } }
+
+    it 'can be overridden using the environment variable OS_PRIVATE_KEY_PATH' do
+      ENV['OS_PRIVATE_KEY_PATH'] = 'env_private_key_path'
+      expect(driver.send(:ssh_private_key_path)).to eq('env_private_key_path')
+    end
+
+    it 'uses the yml value when no environment variable override is present' do
+      ENV['OS_PRIVATE_KEY_PATH'] = nil
+      expect(driver.send(:ssh_private_key_path)).to eq('yml_private_key_path')
+    end
+  end
+
   describe '#setup_ssh' do
     let(:server) { double }
     before(:each) do


### PR DESCRIPTION
Adding the ability to override both OpenStack and SSH configuration using environment variables.

This allows for easier collaboration on tests, as the `.kitchen.yml` may be shared in source control without exposing secrets or requiring shared ssh keys.