### PR TITLE
Test Kitchen 1.4 support

### DIFF
--- a/kitchen-openstack.gemspec
+++ b/kitchen-openstack.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 1.9.3'
 
-  spec.add_dependency 'test-kitchen', '~> 1.2'
+  spec.add_dependency 'test-kitchen', '~> 1.4'
   spec.add_dependency 'fog', '~> 1.18'
   # Newer Fogs throw a warning if unf isn't there :(
   spec.add_dependency 'unf'

--- a/lib/kitchen/driver/openstack.rb
+++ b/lib/kitchen/driver/openstack.rb
@@ -59,7 +59,7 @@ module Kitchen
       default_config :security_groups, nil
       default_config :network_ref, nil
 
-      # TODO no idea how to map this
+      # TODO: no idea how to map this
       # to new transport in test kitchen 1.4,
       # figure it out
       default_config :no_ssh_tcp_check, false
@@ -74,27 +74,19 @@ module Kitchen
       end
 
       validations[:username] = lambda do |attr, val, driver|
-        unless val.nil?
-          deprecation_warn(driver, attr, 'transport.username')
-        end
+        deprecation_warn(driver, attr, 'transport.username') unless val.nil?
       end
 
       validations[:password] = lambda do |attr, val, driver|
-        unless val.nil?
-          deprecation_warn(driver, attr, 'transport.password')
-        end
+        deprecation_warn(driver, attr, 'transport.password') unless val.nil?
       end
 
       validations[:port] = lambda do |attr, val, driver|
-        unless val.nil?
-          deprecation_warn(driver, attr, 'transport.port')
-        end
+        deprecation_warn(driver, attr, 'transport.port') unless val.nil?
       end
 
       validations[:private_key_path] = lambda do |attr, val, driver|
-        unless val.nil?
-          deprecation_warn(driver, attr, 'transport.ssh_key')
-        end
+        deprecation_warn(driver, attr, 'transport.ssh_key') unless val.nil?
       end
 
       # Lifted from https://github.com/test-kitchen/kitchen-ec2
@@ -103,18 +95,10 @@ module Kitchen
       # config with the current state object, so its a bad coupling.  But we
       # can get rid of this when we get rid of these deprecated configs!
       def copy_deprecated_configs(state)
-        if config[:username]
-          state[:username] = config[:username]
-        end
-        if config[:private_key_path]
-          state[:ssh_key] = config[:private_key_path]
-        end
-        if config[:port]
-          state[:port] = config[:port]
-        end
-        if config[:password]
-          state[:password] = config[:password]
-        end
+        state[:username] = config[:username] if config[:username]
+        state[:ssh_key] = config[:private_key_path] if config[:private_key_path]
+        state[:port] = config[:port] if config[:port]
+        state[:password] = config[:password] if config[:password]
       end
 
       def create(state)
@@ -329,7 +313,8 @@ module Kitchen
 
       def get_public_private_ips(server)
         begin
-          pub, priv = server.public_ip_addresses, server.private_ip_addresses
+          pub = server.public_ip_addresses
+          priv = server.private_ip_addresses
         rescue Fog::Compute::OpenStack::NotFound, Excon::Errors::Forbidden
           # See Fog issue: https://github.com/fog/fog/issues/2160
           addrs = server.addresses
@@ -355,7 +340,8 @@ module Kitchen
       end
 
       def parse_ips(pub, priv)
-        pub, priv = Array(pub), Array(priv)
+        pub = Array(pub)
+        priv = Array(priv)
         if config[:use_ipv6]
           [pub, priv].each { |n| n.select! { |i| IPAddr.new(i).ipv6? } }
         else
@@ -373,8 +359,6 @@ module Kitchen
           "#{mkdir_cmd};#{touch_cmd}"
         )
       end
-
-
 
       def disable_ssl_validation
         require 'excon'

--- a/lib/kitchen/driver/openstack.rb
+++ b/lib/kitchen/driver/openstack.rb
@@ -59,44 +59,45 @@ module Kitchen
       default_config :security_groups, nil
       default_config :network_ref, nil
 
-      #TODO no idea how to map this to new transport in
-      #test kitchen 1.4
+      # TODO no idea how to map this
+      # to new transport in test kitchen 1.4,
+      # figure it out
       default_config :no_ssh_tcp_check, false
       default_config :no_ssh_tcp_check_sleep, 120
 
       default_config :block_device_mapping, nil
 
-      # Taken from https://github.com/test-kitchen/kitchen-ec2/blob/master/lib/kitchen/driver/ec2.rb
+      # Taken from kitchen-ec2
       def self.deprecation_warn(driver, old_key, new_key)
-        driver.warn "WARN: The driver[#{driver.class.name}] config key `#{old_key}` " \
-          "is deprecated, please use `#{new_key}`"
+        driver.warn "WARN: The driver[#{driver.class.name}] config key " \
+         "`#{old_key}` is deprecated, please use `#{new_key}`"
       end
 
       validations[:username] = lambda do |attr, val, driver|
         unless val.nil?
-          deprecation_warn(driver, attr, "transport.username")
+          deprecation_warn(driver, attr, 'transport.username')
         end
       end
 
       validations[:password] = lambda do |attr, val, driver|
         unless val.nil?
-          deprecation_warn(driver, attr, "transport.password")
+          deprecation_warn(driver, attr, 'transport.password')
         end
       end
 
       validations[:port] = lambda do |attr, val, driver|
         unless val.nil?
-          deprecation_warn(driver, attr, "transport.port")
+          deprecation_warn(driver, attr, 'transport.port')
         end
       end
 
       validations[:private_key_path] = lambda do |attr, val, driver|
         unless val.nil?
-          deprecation_warn(driver, attr, "transport.ssh_key")
+          deprecation_warn(driver, attr, 'transport.ssh_key')
         end
       end
 
-      # Lifted from https://github.com/test-kitchen/kitchen-ec2/blob/master/lib/kitchen/driver/ec2.rb
+      # Lifted from https://github.com/test-kitchen/kitchen-ec2
       # This copies transport config from the current config object into the
       # state.  This relies on logic in the transport that merges the transport
       # config with the current state object, so its a bad coupling.  But we
@@ -365,8 +366,11 @@ module Kitchen
 
       def add_ohai_hint(state)
         info 'Adding OpenStack hint for ohai'
+        mkdir_cmd = "sudo mkdir -p #{Ohai::Config[:hints_path][0]}"
+        touch_cmd = "sudo touch #{Ohai::Config[:hints_path][0]}/openstack.json"
+
         instance.transport.connection(state).execute(
-          "sudo mkdir -p #{Ohai::Config[:hints_path][0]};sudo touch #{Ohai::Config[:hints_path][0]}/openstack.json"
+          "#{mkdir_cmd};#{touch_cmd}"
         )
       end
 

--- a/lib/kitchen/driver/openstack.rb
+++ b/lib/kitchen/driver/openstack.rb
@@ -102,15 +102,7 @@ module Kitchen
       end
 
       def create(state)
-        unless config[:server_name]
-          if config[:server_name_prefix]
-            config[:server_name] = server_name_prefix(
-              config[:server_name_prefix]
-            )
-          else
-            config[:server_name] = default_name
-          end
-        end
+        set_server_name
         config[:disable_ssl_validation] && disable_ssl_validation
         server = create_server
         state[:server_id] = server.id
@@ -152,6 +144,17 @@ module Kitchen
         required_server_settings.each { |s| server_def[s] = config[s] }
         optional_server_settings.each { |s| server_def[s] = config[s] }
         server_def
+      end
+
+      def set_server_name
+        return if config[:server_name]
+        if config[:server_name_prefix]
+          config[:server_name] = server_name_prefix(
+            config[:server_name_prefix]
+          )
+        else
+          config[:server_name] = default_name
+        end
       end
 
       def required_server_settings

--- a/lib/kitchen/driver/openstack/volume.rb
+++ b/lib/kitchen/driver/openstack/volume.rb
@@ -21,7 +21,7 @@ require 'kitchen'
 
 module Kitchen
   module Driver
-    class Openstack < Kitchen::Driver::SSHBase
+    class Openstack < Kitchen::Driver::Base
       # A class to allow the Kitchen Openstack driver
       # to use Openstack volumes
       #

--- a/spec/kitchen/driver/openstack_spec.rb
+++ b/spec/kitchen/driver/openstack_spec.rb
@@ -29,7 +29,7 @@ describe Kitchen::Driver::Openstack do
 
   before(:each) do
     allow_any_instance_of(described_class).to receive(:instance)
-    .and_return(instance)
+      .and_return(instance)
     allow(File).to receive(:exist?).and_call_original
     allow(File).to receive(:exist?).with(dsa).and_return(true)
     allow(File).to receive(:exist?).with(rsa).and_return(true)
@@ -169,9 +169,10 @@ describe Kitchen::Driver::Openstack do
       connection = double
       expect(connection).to receive(:wait_until_ready).and_return(true)
       allow(connection).to receive(:execute).with(/openstack.json/)
-      transport = double()
-      allow(transport).to receive(:connection).with(hash_including(
-        server_id: 'test123', hostname: "1.2.3.4"
+      transport = double
+      allow(transport).to receive(:connection).with(
+        hash_including(
+         server_id: 'test123', hostname: '1.2.3.4'
         )).and_return(connection)
       allow(d).to receive(:transport).and_return(transport)
       d

--- a/spec/kitchen/driver/openstack_spec.rb
+++ b/spec/kitchen/driver/openstack_spec.rb
@@ -678,7 +678,7 @@ describe Kitchen::Driver::Openstack do
           flavor_ref: '1',
           availability_zone: nil,
           public_key_path: 'tarpals',
-        user_data: data)
+          user_data: data)
         driver.send(:create_server)
       end
     end
@@ -751,7 +751,7 @@ describe Kitchen::Driver::Openstack do
 
     it 'generates a name with the selected prefix' do
       expect(driver.send(:server_name_prefix, prefix))
-      .to match(/^parsnip-(\S*)/)
+        .to match(/^parsnip-(\S*)/)
     end
 
     context 'very long prefix provided' do
@@ -759,7 +759,7 @@ describe Kitchen::Driver::Openstack do
 
       it 'limits the generated name to 63 characters' do
         expect(driver.send(:server_name_prefix, long_prefix).length)
-        .to be <= (63)
+          .to be <= (63)
       end
     end
 
@@ -768,19 +768,19 @@ describe Kitchen::Driver::Openstack do
 
       it 'strips out the dots to prevent bad server names' do
         expect(driver.send(:server_name_prefix, bad_char_prefix))
-        .to_not include('.')
+          .to_not include('.')
       end
 
       it 'strips out all but the one hyphen separator' do
         expect(driver.send(:server_name_prefix, bad_char_prefix)
-               .count('-')).to eq(1)
+          .count('-')).to eq(1)
       end
     end
 
     context 'blank prefix' do
       it 'generates fully random server name' do
         expect(driver.send(:server_name_prefix, ''))
-        .to match(/potatoes-user-host-(\S*)/)
+          .to match(/potatoes-user-host-(\S*)/)
       end
     end
   end
@@ -828,7 +828,7 @@ describe Kitchen::Driver::Openstack do
 
     it 'associates the IP address with the server' do
       expect(driver.send(:attach_ip, server, ip)).to eq(
-      [{ 'version' => 4, 'addr' => ip }])
+        [{ 'version' => 4, 'addr' => ip }])
     end
   end
 
@@ -908,9 +908,9 @@ describe Kitchen::Driver::Openstack do
         s = double('server')
         allow(s).to receive(:addresses).and_return(addresses)
         allow(s).to receive(:public_ip_addresses).and_raise(
-        Fog::Compute::OpenStack::NotFound)
+          Fog::Compute::OpenStack::NotFound)
         allow(s).to receive(:private_ip_addresses).and_raise(
-        Fog::Compute::OpenStack::NotFound)
+          Fog::Compute::OpenStack::NotFound)
         s
       end
 
@@ -1046,8 +1046,8 @@ describe Kitchen::Driver::Openstack do
       expect(connection).to receive(:execute)
         .with(/sudo mkdir.*touch.*openstack.json/)
       transport = double
-      allow(transport).to receive(:connection).
-        with(any_args).and_return(connection)
+      allow(transport).to receive(:connection)
+        .with(any_args).and_return(connection)
       allow(d).to receive(:transport).and_return(transport)
       d
     end

--- a/spec/kitchen/driver/openstack_spec.rb
+++ b/spec/kitchen/driver/openstack_spec.rb
@@ -1045,26 +1045,23 @@ describe Kitchen::Driver::Openstack do
     end
   end
 
-
   describe '#add_ohai_hint' do
     let(:state) { { hostname: 'host' } }
     let(:instance) do
       d = super()
       connection = double
-      expect(connection).to receive(:execute).with(
-        "sudo mkdir -p #{Ohai::Config[:hints_path][0]};sudo touch #{Ohai::Config[:hints_path][0]}/openstack.json"
-        ) 
-      transport = double()
-      allow(transport).to receive(:connection).with(any_args).and_return(connection)
+      expect(connection).to receive(:execute)
+        .with(/sudo mkdir.*touch.*openstack.json/)
+      transport = double
+      allow(transport).to receive(:connection).
+        with(any_args).and_return(connection)
       allow(d).to receive(:transport).and_return(transport)
       d
     end
     it 'opens an SSH session to the server' do
-      res = driver.send(:add_ohai_hint, state)
+      driver.send(:add_ohai_hint, state)
     end
   end
-
-
 
   describe '#disable_ssl_validation' do
     it 'turns off Excon SSL cert validation' do

--- a/spec/kitchen/driver/openstack_spec.rb
+++ b/spec/kitchen/driver/openstack_spec.rb
@@ -17,14 +17,11 @@ describe Kitchen::Driver::Openstack do
   let(:dsa) { File.expand_path('~/.ssh/id_dsa') }
   let(:rsa) { File.expand_path('~/.ssh/id_rsa') }
   let(:instance_name) { 'potatoes' }
-
-
   let(:instance) do
     double(
       name: instance_name, logger: logger, to_str: 'instance'
     )
   end
-
   let(:driver) { described_class.new(config) }
 
   before(:each) do
@@ -162,8 +159,6 @@ describe Kitchen::Driver::Openstack do
       allow(d).to receive(:do_ssh_setup).and_return(true)
       d
     end
-
-
     let(:instance) do
       d = super()
       connection = double
@@ -172,14 +167,11 @@ describe Kitchen::Driver::Openstack do
       transport = double
       allow(transport).to receive(:connection).with(
         hash_including(
-         server_id: 'test123', hostname: '1.2.3.4'
+          server_id: 'test123', hostname: '1.2.3.4'
         )).and_return(connection)
       allow(d).to receive(:transport).and_return(transport)
       d
     end
-
-
-
 
     context 'required options provided' do
       let(:config) do


### PR DESCRIPTION
Test Kitchen refactored a transport layer, moving some previous driver logic into test kitchen itself.  I wasn't able to use my existing .kitchen.yml (though it possibly could have worked by simply editing in the transport layer).

Anyway, this change updates it, using kitchen-ec2 as a guide.  As a side effect it now works with windows, and would hopefully close https://github.com/test-kitchen/kitchen-openstack/issues/45