### PR TITLE
2.0.0.dev.1

### DIFF
--- a/lib/kitchen/driver/openstack.rb
+++ b/lib/kitchen/driver/openstack.rb
@@ -93,9 +93,7 @@ module Kitchen
           attach_ip_from_pool(server, config[:floating_ip_pool])
         end
         wait_for_server(state)
-        if bourne_shell?
-          setup_ssh(server, state)
-        end
+        setup_ssh(server, state) if bourne_shell?
         add_ohai_hint(state)
       rescue Fog::Errors::Error, Excon::Errors::Error => ex
         raise ActionFailed, ex.message

--- a/lib/kitchen/driver/openstack.rb
+++ b/lib/kitchen/driver/openstack.rb
@@ -61,7 +61,7 @@ module Kitchen
       default_config :network_ref, nil
       default_config :no_ssh_tcp_check, false
       default_config :no_ssh_tcp_check_sleep, 120
-      default_config :winrm_wait, 0
+      default_config :winrm_wait, nil
       default_config :block_device_mapping, nil
 
       required_config :private_key_path
@@ -94,7 +94,6 @@ module Kitchen
         end
         wait_for_server(state)
         if bourne_shell?
-          wait_for_ssh_key_access(state)
           setup_ssh(server, state)
         end
         add_ohai_hint(state)
@@ -114,25 +113,6 @@ module Kitchen
       end
 
       private
-
-      def wait_for_ssh_key_access(state)
-        new_state = build_ssh_args(state)
-        new_state[2][:number_of_password_prompts] = 0
-        info 'Checking ssh key authentication'
-        30.times do
-          ssh = Fog::SSH.new(*new_state)
-          begin
-            ssh.run([%(uname -a)])
-          rescue => e
-            info "Server not yet accepting SSH key: #{e.message}"
-            sleep 1
-          else
-            info 'SSH key authetication successful'
-            return
-          end
-        end
-        fail "30 seconds went by and we couldn't connect, somethings broken"
-      end
 
       def openstack_server
         server_def = {
@@ -363,7 +343,6 @@ module Kitchen
       end
 
       def setup_ssh(server, state)
-        tcp_check(state)
         if config[:key_name]
           info "Using OpenStack keypair <#{config[:key_name]}>"
         end
@@ -384,19 +363,6 @@ module Kitchen
           %(echo "#{pub_key}" >> ~/.ssh/authorized_keys),
           %(passwd -l #{config[:username]})
         ])
-      end
-
-      def tcp_check(state)
-        # allow driver config to bypass SSH tcp check -- because
-        # it doesn't respect ssh_config values that might be required
-        if config[:no_ssh_tcp_check]
-          sleep(config[:no_ssh_tcp_check_sleep])
-        else
-          wait_for_sshd(state[:hostname],
-                        config[:username],
-                        port: config[:port])
-        end
-        info "Server #{state[:hostname]} has ssh ready..."
       end
 
       def disable_ssl_validation

--- a/lib/kitchen/driver/openstack_version.rb
+++ b/lib/kitchen/driver/openstack_version.rb
@@ -21,6 +21,6 @@ module Kitchen
   #
   # @author Jonathan Hartman <j@p4nt5.com>
   module Driver
-    OPENSTACK_VERSION = '2.0.0.dev'
+    OPENSTACK_VERSION = '2.0.0.dev.1'
   end
 end

--- a/spec/kitchen/driver/openstack_spec.rb
+++ b/spec/kitchen/driver/openstack_spec.rb
@@ -1105,43 +1105,6 @@ describe Kitchen::Driver::Openstack do
     end
   end
 
-  describe '#setup_ssh' do
-    let(:server) { double }
-    before(:each) do
-      [:tcp_check, :do_ssh_setup].each do |m|
-        allow_any_instance_of(described_class).to receive(m)
-      end
-    end
-
-    it 'calls the TCP check' do
-      expect_any_instance_of(described_class).to receive(:tcp_check).with(state)
-      driver.send(:setup_ssh, server, state)
-    end
-  end
-
-  describe '#tcp_check' do
-    let(:state) { { hostname: 'hostname' } }
-
-    context 'standard SSH check' do
-      it 'calls the normal Kitchen SSH wait' do
-        expect_any_instance_of(described_class).not_to receive(:sleep)
-        expect_any_instance_of(described_class).to receive(:wait_for_sshd)
-          .with('hostname', 'root', port: '22')
-        driver.send(:tcp_check, state)
-      end
-    end
-
-    context 'override SSH wait' do
-      let(:config) { { no_ssh_tcp_check: true } }
-
-      it 'sleeps instead of monitoring the SSH port' do
-        expect_any_instance_of(described_class).not_to receive(:wait_for_sshd)
-        expect_any_instance_of(described_class).to receive(:sleep).with(120)
-        driver.send(:tcp_check, state)
-      end
-    end
-  end
-
   describe '#disable_ssl_validation' do
     it 'turns off Excon SSL cert validation' do
       expect(driver.send(:disable_ssl_validation)).to eq(false)

--- a/spec/kitchen/driver/openstack_spec.rb
+++ b/spec/kitchen/driver/openstack_spec.rb
@@ -196,6 +196,7 @@ describe Kitchen::Driver::Openstack do
       allow(d).to receive(:add_ohai_hint).and_return(true)
       allow(d).to receive(:do_ssh_setup).and_return(true)
       allow(d).to receive(:sleep)
+      allow(d).to receive(:wait_for_ssh_key_access).and_return('SSH key authetication successful') # rubocop:disable Metrics/LineLength
       d
     end
 


### PR DESCRIPTION
- fixed default winrm_wait to `nil`
- removed code that transport layer will take care of
- removed tests per that