### PR TITLE
Support all Fog OpenStack options

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ driver:
 The `image_ref` and `flavor_ref` options can be specified as an exact id,
 an exact name, or as a regular expression matching the name of the image or flavor.
 
+All of Fog's `openstack` options (`openstack_domain_name`, `openstack_project_name`,
+...) are supported. This includes support for the OpenStack Identity v3 API.
+
 Test Kitchen 1.4 supports multiple transports, and transports can be configure globally:
 
 ```yaml

--- a/lib/kitchen/driver/openstack.rb
+++ b/lib/kitchen/driver/openstack.rb
@@ -118,7 +118,7 @@ module Kitchen
           provider: 'OpenStack'
         }
         required_server_settings.each { |s| server_def[s] = config[s] }
-        optional_server_settings.each { |s| server_def[s] = config[s] }
+        optional_server_settings.each { |s| server_def[s] = config[s] if config[s] } # rubocop:disable Metrics/LineLength
         server_def
       end
 
@@ -127,7 +127,9 @@ module Kitchen
       end
 
       def optional_server_settings
-        [:openstack_tenant, :openstack_region, :openstack_service_name]
+        Fog::Compute::OpenStack.recognized.select do |k|
+          k.to_s.start_with?('openstack')
+        end - required_server_settings
       end
 
       def network

--- a/spec/kitchen/driver/openstack_spec.rb
+++ b/spec/kitchen/driver/openstack_spec.rb
@@ -330,10 +330,10 @@ describe Kitchen::Driver::Openstack do
 
   describe '#optional_server_settings' do
     it 'returns the optional settings for an OpenStack server' do
-      expected = [
-        :openstack_tenant, :openstack_region, :openstack_service_name
+      excluded = [
+        :openstack_username, :openstack_api_key, :openstack_auth_url
       ]
-      expect(driver.send(:optional_server_settings)).to eq(expected)
+      expect(driver.send(:optional_server_settings)).not_to include(*excluded)
     end
   end
 


### PR DESCRIPTION
This loads all the `openstack` options directly from Fog and calculates the optional settings so we don't have to chase OpenStack / Fog changes.

With [fog 1.33.0](https://github.com/fog/fog/blob/v1.33.0/lib/fog/openstack/compute.rb#L7-L15), `#optional_server_settings` returns:

```ruby
[
  :openstack_auth_token, :openstack_management_url, :openstack_service_type, 
  :openstack_service_name, :openstack_tenant, :openstack_tenant_id, 
  :openstack_identity_endpoint, :openstack_region, :openstack_endpoint_type, 
  :openstack_project_name, :openstack_project_id, :openstack_project_domain, 
  :openstack_user_domain, :openstack_domain_name, :openstack_project_domain_id, 
  :openstack_user_domain_id, :openstack_domain_id
]
```

I originally intended to only add the OpenStack identity v3 options, but I think this ended up as a neater solution.