### PR TITLE
Load openstack_version for plugin_version

### DIFF
--- a/lib/kitchen/driver/openstack.rb
+++ b/lib/kitchen/driver/openstack.rb
@@ -21,6 +21,7 @@
 require 'kitchen'
 require 'fog'
 require 'ohai'
+require_relative 'openstack_version'
 require_relative 'openstack/volume'
 
 module Kitchen


### PR DESCRIPTION
Saw this on a fresh `bundle install`:

```
E, [2015-09-16T13:33:21.697624 #98976] ERROR -- Kitchen: ------Exception-------
E, [2015-09-16T13:33:21.697750 #98976] ERROR -- Kitchen: Class: Kitchen::ClientError
E, [2015-09-16T13:33:21.697780 #98976] ERROR -- Kitchen: Message: Could not load the 'openstack' driver from the load path. Please ensure that your driver is installed as a gem or included in your Gemfile if using Bundler.
E, [2015-09-16T13:33:21.697806 #98976] ERROR -- Kitchen: ---Nested Exception---
E, [2015-09-16T13:33:21.697837 #98976] ERROR -- Kitchen: Class: NameError
E, [2015-09-16T13:33:21.697858 #98976] ERROR -- Kitchen: Message: uninitialized constant Kitchen::Driver::OPENSTACK_VERSION
```

This PR loads `openstack_version` to define the constant.