### PR TITLE
Don't create instance if name is already created

### DIFF
--- a/lib/kitchen/driver/openstack.rb
+++ b/lib/kitchen/driver/openstack.rb
@@ -73,15 +73,24 @@ module Kitchen
         end
       end
 
+      # Set the proper server name in the config
+      def config_server_name
+        return if config[:server_name]
+
+        if config[:server_name_prefix]
+          config[:server_name] = server_name_prefix(
+            config[:server_name_prefix]
+          )
+        else
+          config[:server_name] = default_name
+        end
+      end
+
       def create(state)
-        unless config[:server_name]
-          if config[:server_name_prefix]
-            config[:server_name] = server_name_prefix(
-              config[:server_name_prefix]
-            )
-          else
-            config[:server_name] = default_name
-          end
+        config_server_name
+        if state[:server_id]
+          info "#{config[:server_name]} (#{state[:server_id]}) already exists."
+          return
         end
         disable_ssl_validation if config[:disable_ssl_validation]
         server = create_server

--- a/spec/kitchen/driver/openstack_spec.rb
+++ b/spec/kitchen/driver/openstack_spec.rb
@@ -232,6 +232,14 @@ describe Kitchen::Driver::Openstack do
         driver.create(state)
       end
     end
+
+    context 'when a server is already created' do
+      it 'does not create a new instance' do
+        state[:server_id] = '123'
+        expect(driver).not_to receive(:create_server)
+        driver.create(state)
+      end
+    end
   end
 
   describe '#destroy' do


### PR DESCRIPTION
This should address #67. The introduction of `config_server_name` was necessary to avoid these robocop offenses (which cropped up after adding the new conditional in create)

```
lib/kitchen/driver/openstack.rb:76:7: C: Assignment Branch Condition size for create is too high. [42.8/41]
      def create(state)
      ^^^
lib/kitchen/driver/openstack.rb:76:7: C: Cyclomatic complexity for create is too high. [9/8]
      def create(state)
      ^^^
lib/kitchen/driver/openstack.rb:76:7: C: Perceived complexity for create is too high. [11/10]
      def create(state)
      ^^^
```

I opted to shift that little bit of logic into its own function to avoid these violations.