### PR TITLE
Added glance_cache_wait

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,15 @@ Your OpenStack compute service name.
 Your OpenStack network name used to connect to, if you have only private network
 connections you want declare this.
 
+### glance\_cache\_wait
+
+`glance_cache_wait` is necessary evil to make sure glance caches the OS image on the
+compute node you've pointed to. For most images you won't need to change this,
+but for larger images you may want to change this number.
+
+The default is `30`.
+
+
 ### server\_wait
 
 `server_wait` is a workaround to deal with how some VMs with `cloud-init`.

--- a/lib/kitchen/driver/openstack.rb
+++ b/lib/kitchen/driver/openstack.rb
@@ -62,7 +62,7 @@ module Kitchen
       default_config :network_ref, nil
       default_config :no_ssh_tcp_check, false
       default_config :no_ssh_tcp_check_sleep, 120
-      default_config :winrm_wait, nil
+      default_config :glance_cache_wait, 30
       default_config :block_device_mapping, nil
 
       required_config :private_key_path
@@ -97,7 +97,7 @@ module Kitchen
         state[:server_id] = server.id
         info "OpenStack instance with ID of <#{state[:server_id]}> is ready." # rubocop:disable Metrics/LineLength
         # this is due to the glance_caching issues. Annoying yes, but necessary.
-        sleep 30
+        sleep config[:glance_cache_wait]
         if config[:floating_ip]
           attach_ip(server, config[:floating_ip])
         elsif config[:floating_ip_pool]


### PR DESCRIPTION
- This is so you can make the sleep for glance cache issue
  configureable. This resolves #117.