### PR TITLE
Fixes blocking issue where ohai hint file could not be created on Windows, failing kitchen create

### DIFF
--- a/lib/kitchen/driver/openstack.rb
+++ b/lib/kitchen/driver/openstack.rb
@@ -356,7 +356,7 @@ module Kitchen
           mkdir_cmd = "mkdir #{hints_path}"
           touch_cmd = "'{}' > #{hints_path}\\openstack.json"
           instance.transport.connection(state).execute(
-            "#{mkdir_cmd} && #{touch_cmd}"
+            "#{mkdir_cmd}; #{touch_cmd}"
           )
         end
       end


### PR DESCRIPTION
Command separator when used on Windows (PowerShell) changed to a semi-colon.
Tested on Windows 2012 and Windows 2012 R2.

Fixes #122 