### PR TITLE
Allow user to wait for log entry line(s) before doing transport check

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,18 +164,31 @@ connections you want declare this.
 ### glance\_cache\_wait\_timeout
 When OpenStack downloads the image into cache, it takes extra time to provision.  Timeout controls maximum amount of time to wait for machine to move from the Build/Spawn phase to Active.
 
-### server\_wait
+### console\_log\_expression
 
-`server_wait` is a workaround to deal with how some VMs with `cloud-init`.
-Some clouds need this some, most OpenStack instances don't. This is a stop gap
-wait makes sure that the machine is in a good state to work with. Ideally the
-transport layer in Test-Kitchen will have a more intelligent way to deal with this.
-There will be a dot that appears every 10 seconds as the timer counts down.
-You may want to add this for **WinRM** instances due to the multiple restarts that
-happen on creation and boot. A good default is `300` seconds to make sure it's
-in a good state.
+Allows for VMs to execute `cloud-init` or log to the instance console
+and not falsely detect the VM as up.  Setting this expression to a regular
+expression will block the transport logic until a certain log message
+is written.  This allows `cloud-init` to execute any arbitrary script
+and wait for it to finish.
 
-The default is `0`.
+The default is `nil`, which is disabled.
+
+### console\_log\_match\_count
+
+How many times to look for `console_log_expression` inside the log.  If
+the script is sent in via userdata, the line may show as userdata is
+printed once when the script is sent over, and another when executed.
+
+The default is 1
+
+### console\_log\_wait\_timeout
+
+If the `console_log_expression` is defined, how long to wait for the log
+messages to show up.  This value is in seconds and is only activated if
+`console_log_expression` parameter is defined
+
+The default is 600
 
 ### security\_groups
 


### PR DESCRIPTION
Typically if you have cloud-init, you want to wait until the script is done running before moving on.  If we add a regular expression to check for, we can now wait for the log entry to show up.

This enables many use cases and gets rid of race conditions.  Some examples:
* Wait for SSH to be reconfigured with user_data
* Wait for SSH Key injection to happen with OpenStack image - cloud-init
* Wait for sysprep to finish running (Windows) WinRM runs during sysprep, so driver returns to early.
* Allow domain join and reboot via user_data
* etc

Possibilities are endless in what could be supported

Wait for #120 first