### PR TITLE
3.0.0 Release of kitchen-openstack

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,14 +128,6 @@ driver:
   user_data: cloud_init
 ```
 
-### username
-
-**Deprecated** SSH User name, you should be using transport now.
-
-### password
-
-**Deprecated** SSH password, you should be using transport now.
-
 ### port
 
 Set the SSH port for the remote access.

--- a/kitchen-openstack.gemspec
+++ b/kitchen-openstack.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'rubocop', '0.34.1'
+  spec.add_development_dependency 'rubocop', '~> 0.36'
   spec.add_development_dependency 'cane'
   spec.add_development_dependency 'countloc'
   spec.add_development_dependency 'rspec'

--- a/kitchen-openstack.gemspec
+++ b/kitchen-openstack.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'rubocop'
+  spec.add_development_dependency 'rubocop', '0.34.1'
   spec.add_development_dependency 'cane'
   spec.add_development_dependency 'countloc'
   spec.add_development_dependency 'rspec'

--- a/lib/kitchen/driver/openstack.rb
+++ b/lib/kitchen/driver/openstack.rb
@@ -66,7 +66,7 @@ module Kitchen
       required_config :private_key_path
       required_config :public_key_path do |_, value, driver|
         if value.nil? && driver[:key_name].nil?
-          fail(UserError,
+          fail(UserError, # rubocop:disable SignalException
                'Either a `:public_key_path` or `:key_name` is required')
         end
       end
@@ -212,21 +212,21 @@ module Kitchen
 
       def find_image(image_ref)
         image = find_matching(compute.images, image_ref)
-        fail(ActionFailed, 'Image not found') unless image
+        fail(ActionFailed, 'Image not found') unless image # rubocop:disable Metrics/LineLength, SignalException
         debug "Selected image: #{image.id} #{image.name}"
         image
       end
 
       def find_flavor(flavor_ref)
         flavor = find_matching(compute.flavors, flavor_ref)
-        fail(ActionFailed, 'Flavor not found') unless flavor
+        fail(ActionFailed, 'Flavor not found') unless flavor # rubocop:disable Metrics/LineLength, SignalException
         debug "Selected flavor: #{flavor.id} #{flavor.name}"
         flavor
       end
 
       def find_network(network_ref)
         net = find_matching(network.networks.all, network_ref)
-        fail(ActionFailed, 'Network not found') unless net
+        fail(ActionFailed, 'Network not found') unless net # rubocop:disable Metrics/LineLength, SignalException
         debug "Selected net: #{net.id} #{net.name}"
         net
       end
@@ -281,7 +281,7 @@ module Kitchen
             i.ip if i.fixed_ip.nil? && i.instance_id.nil? && i.pool == pool
           end.compact
           if free_addrs.empty?
-            fail ActionFailed, "No available IPs in pool <#{pool}>"
+            fail ActionFailed, "No available IPs in pool <#{pool}>" # rubocop:disable Metrics/LineLength, SignalException
           end
           config[:floating_ip] = free_addrs[0]
           attach_ip(server, free_addrs[0])
@@ -332,7 +332,7 @@ module Kitchen
         pub, priv = parse_ips(pub, priv)
         pub[config[:public_ip_order].to_i] ||
           priv[config[:private_ip_order].to_i] ||
-          fail(ActionFailed, 'Could not find an IP')
+          fail(ActionFailed, 'Could not find an IP') # rubocop:disable Metrics/LineLength, SignalException
       end
 
       def parse_ips(pub, priv)

--- a/lib/kitchen/driver/openstack/volume.rb
+++ b/lib/kitchen/driver/openstack/volume.rb
@@ -64,7 +64,7 @@ module Kitchen
           @logger.debug "Waiting for volume to be ready for #{creation_timeout} seconds" # rubocop:disable Metrics/LineLength
           vol_model.wait_for(creation_timeout) do
             sleep(1)
-            fail('Failed to make volume') if status.downcase == 'error'
+            fail('Failed to make volume') if status.casecmp('error'.downcase).zero? # rubocop:disable Metrics/LineLength, SignalException
             ready?
           end
 

--- a/lib/kitchen/driver/openstack_version.rb
+++ b/lib/kitchen/driver/openstack_version.rb
@@ -3,7 +3,7 @@
 # Author:: Jonathan Hartman (<j@p4nt5.com>)
 #
 # Copyright (C) 2013-2015, Jonathan Hartman
-# Copyright (C) 2015, Chef Software Inc
+# Copyright (C) 2015-2016, Chef Software Inc
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,6 +22,6 @@ module Kitchen
   #
   # @author Jonathan Hartman <j@p4nt5.com>
   module Driver
-    OPENSTACK_VERSION = '2.1.1'
+    OPENSTACK_VERSION = '3.0.0.pre.1'
   end
 end

--- a/lib/kitchen/driver/openstack_version.rb
+++ b/lib/kitchen/driver/openstack_version.rb
@@ -22,6 +22,6 @@ module Kitchen
   #
   # @author Jonathan Hartman <j@p4nt5.com>
   module Driver
-    OPENSTACK_VERSION = '3.0.0.pre.1'
+    OPENSTACK_VERSION = '3.0.0.pre.1'.freeze
   end
 end

--- a/spec/kitchen/driver/openstack_spec.rb
+++ b/spec/kitchen/driver/openstack_spec.rb
@@ -120,11 +120,6 @@ describe Kitchen::Driver::Openstack do
         end
       end
 
-      it 'defaults to SSH with root user on port 22' do
-        expect(driver[:username]).to eq('root')
-        expect(driver[:port]).to eq('22')
-      end
-
       nils = [
         :server_name,
         :openstack_tenant,
@@ -1110,83 +1105,6 @@ describe Kitchen::Driver::Openstack do
         it 'returns empty lists' do
           expect(driver.send(:parse_ips, nil, nil)).to eq([[], []])
         end
-      end
-    end
-  end
-
-  describe '#setup_ssh' do
-    let(:config) { { public_key_path: '/pub_key' } }
-    let(:config) do
-      {
-        public_key_path: '/pub_key',
-        key_name: 'OpenStackKey'
-      }
-    end
-
-    let(:server) { double(password: 'aloha') }
-    let(:state) { { hostname: 'host' } }
-    let(:read) { double(read: 'a_key') }
-    let(:ssh) { double(run: true) }
-
-    before(:each) do
-      allow(driver).to receive(:open).with(config[:public_key_path])
-        .and_return(read)
-    end
-
-    context 'sets the ssh_key state' do
-      before do
-        allow(driver).to receive(:bourne_shell?).and_return(false)
-        allow(driver).to receive(:do_ssh_setup).and_return(nil)
-      end
-
-      it 'does not execute the ssh setup' do
-        expect(driver).not_to receive(:do_ssh_setup)
-        driver.send(:setup_ssh, server, state)
-      end
-    end
-  end
-
-  describe '#do_ssh_setup' do
-    let(:config) { { public_key_path: '/pub_key' } }
-    let(:server) { double(password: 'aloha') }
-    let(:state) { { hostname: 'host' } }
-    let(:read) { double(read: 'a_key') }
-    let(:ssh) { double(run: true) }
-
-    before(:each) do
-      allow(driver).to receive(:open).with(config[:public_key_path])
-        .and_return(read)
-    end
-
-    context 'when executed in a non-bourne shell' do
-      before do
-        allow(driver).to receive(:bourne_shell?).and_return(false)
-      end
-
-      it 'does not execute the ssh setup' do
-        expect(driver).not_to receive(:setup_ssh)
-      end
-    end
-
-    it 'opens an SSH session to the server' do
-      expect(Fog::SSH).to receive(:new).with(state[:hostname],
-                                             'root',
-                                             password: 'aloha').and_return(ssh)
-      expect(ssh).to receive(:run).with([
-        'mkdir .ssh',
-        'echo "a_key" >> ~/.ssh/authorized_keys',
-        'passwd -l root'
-      ])
-      driver.send(:do_ssh_setup, state, config, server)
-    end
-
-    context 'a configured SSH password' do
-      let(:config) { super().merge(password: '12345') }
-
-      it 'uses the configured password' do
-        expect(Fog::SSH).to receive(:new)
-          .with(state[:hostname], 'root', password: '12345').and_return(ssh)
-        driver.send(:do_ssh_setup, state, config, server)
       end
     end
   end

--- a/spec/kitchen/driver/openstack_spec.rb
+++ b/spec/kitchen/driver/openstack_spec.rb
@@ -70,7 +70,7 @@ describe Kitchen::Driver::Openstack do
     end
   end
 
-  describe '#initialize'do
+  describe '#initialize' do
     context 'default options' do
       it 'uses the normal SSH status check' do
         expect(driver[:no_ssh_tcp_check]).to eq(false)
@@ -736,7 +736,7 @@ describe Kitchen::Driver::Openstack do
       let(:hostname) { 'ab.c' * 20 }
 
       it 'limits the generated name to 63 characters' do
-        expect(driver.send(:default_name).length).to be <= (63)
+        expect(driver.send(:default_name).length).to be <= 63
       end
     end
 
@@ -794,7 +794,7 @@ describe Kitchen::Driver::Openstack do
 
       it 'limits the generated name to 63 characters' do
         expect(driver.send(:server_name_prefix, long_prefix).length)
-          .to be <= (63)
+          .to be <= 63
       end
     end
 


### PR DESCRIPTION
- Updated README
- Removed the `:username` and `:password` options
- Removed the `:winrm_wait` because it wasn't being used
- Removed the `setup_ssh` because it was doubling up what transport was doing
- Removed the old tests for the changes above
- Updated rubocop to ~> 0.36
- Fixed SignalExceptions
- Froze the version.rb per rubocop