### PR TITLE
fix failing to get IP when there is no public IP.

### DIFF
--- a/lib/kitchen/driver/openstack.rb
+++ b/lib/kitchen/driver/openstack.rb
@@ -330,7 +330,7 @@ module Kitchen
         end
 
         pub, priv = get_public_private_ips(server)
-        priv ||= server.ip_addresses unless pub
+        priv = server.ip_addresses if Array(pub).empty? && Array(priv).empty?
         pub, priv = parse_ips(pub, priv)
         pub[config[:public_ip_order].to_i] ||
           priv[config[:private_ip_order].to_i] ||


### PR DESCRIPTION
for scenario like this:

```
pub => []
priv => []
server.ip_addresses = ['x.x.x.x']
```
