### PR TITLE
Defer ssh key handling to transport.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,6 @@ gemfile:
   - Gemfile
 
 rvm:
-  - 2.0.0
   - ruby-head
+  - 2.3.1
+  - 2.2.5

--- a/README.md
+++ b/README.md
@@ -104,30 +104,6 @@ specified then the `server_name` takes precedence.
 
 If you want to have a static prefix for a random server name.
 
-### private\_key\_path
-
-The path to your private ssh key.
-
-### public\_key\_path
-
-The path to your public ssh key.
-
-If a `key_name` is provided it will be used instead of any
-`public_key_path` that is specified.
-
-If a `key_name` is provided without any `private_key_path`, unexpected
-behavior may result if your local RSA/DSA private key doesn't match that
-OpenStack key. If you do key injection via `cloud-init` like this issue:
-[#77](https://github.com/test-kitchen/kitchen-openstack/issues/77). The
-`key_name` should be a blank string if you need to skip it. Example:
-
-```yml
-driver:
-  [-- snip --]
-  key_name: ""
-  user_data: cloud_init
-```
-
 ### port
 
 Set the SSH port for the remote access.
@@ -225,6 +201,14 @@ The default is `false`.
 
 **Deprecated** You should be using transport now. This will sleep for so many seconds. `no_ssh_tcp_check` needs
 to be set to `true`.
+
+### private\_key\_path
+
+**Deprecated** You should be using transport now. The guest image should use `cloud-init` or some other method to fetch key from meta-data service.
+
+### public\_key\_path
+
+**Deprecated** You should be using transport now. The guest image should use `cloud-init` or some other method to fetch key from meta-data service.
 
 ## Disk Configuration
 
@@ -368,9 +352,10 @@ driver:
   require_chef_omnibus: [e.g. 'true' or a version number if you need Chef]
   image_ref: [SERVER IMAGE ID]
   flavor_ref: [SERVER FLAVOR ID]
+  key_name: [KEY NAME]
 
 transport:
-  ssh_key: /path/to/id_rsa  # probably the same as private_key_path
+  ssh_key: /path/to/id_rsa #Path to private key that matches the above openstack key_name
   connection_timeout: 10
   connection_retries: 5
   username: ubuntu

--- a/kitchen-openstack.gemspec
+++ b/kitchen-openstack.gemspec
@@ -4,7 +4,7 @@ lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'kitchen/driver/openstack_version'
 
-Gem::Specification.new do |spec|
+Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
   spec.name          = 'kitchen-openstack'
   spec.version       = Kitchen::Driver::OPENSTACK_VERSION
   spec.authors       = ['Jonathan Hartman', 'JJ Asghar']


### PR DESCRIPTION
PR 136 Removed all driver specific ssh methods and options, deferring those operations to ssh transport code (and guest image).

The public/private key options were inadvertently left as required
options, and the readme was not updated to reflect the changes.

This commit removes the public/private key path options and updates the
readme.
