### PR TITLE
Dynamically allocate Floating IP for the test server.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,8 +3,12 @@ CyclomaticComplexity:
 MethodLength:
   Max: 30
 ClassLength:
-  Max: 300
+  Max: 320
 ClassVars:
+  Enabled: false
+BlockLength:
+  Enabled: false
+ConditionalAssignment:
   Enabled: false
 PerceivedComplexity:
   Max: 10

--- a/README.md
+++ b/README.md
@@ -271,9 +271,16 @@ Any floating IP will be the IP used for Test Kitchen's Remote calls to the node.
 
 ### floating\_ip\_pool
 
-A `floating_ip_pool` can be provided to acquire the first free floating ip from
-the pool to attach to the instance. It will be the IP used for Test Kitchen's
-Remote calls to the node.
+A `floating_ip_pool` can be provided to allocate a floating IP from
+the pool to the instance. If `allocate_floating_ip` is true, the IP will be allocated,
+otherwise the first free floating IP will be used.  It will be the IP used for
+Test Kitchen's Remote calls to the node. If allocated, the floating IP will be
+released once the instance is destroyed.
+
+### allocate\_floating\_ip
+
+If true, allocate a new IP from the specified `floating_ip_pool` and release is afterwards.
+Otherwise, if false (the default), an existing allocated IP.
 
 ### \[public\|private\]\_ip\_order
 

--- a/kitchen-openstack.gemspec
+++ b/kitchen-openstack.gemspec
@@ -4,7 +4,7 @@ lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'kitchen/driver/openstack_version'
 
-Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
+Gem::Specification.new do |spec|
   spec.name          = 'kitchen-openstack'
   spec.version       = Kitchen::Driver::OPENSTACK_VERSION
   spec.authors       = ['Jonathan Hartman', 'JJ Asghar']

--- a/spec/kitchen/driver/openstack_spec.rb
+++ b/spec/kitchen/driver/openstack_spec.rb
@@ -251,6 +251,39 @@ describe Kitchen::Driver::Openstack do
         driver.destroy(state)
       end
     end
+
+    context 'Deallocate floating IP' do
+      let(:config) do
+        {
+          floating_ip_pool: 'swimmers',
+          allocate_floating_ip: true
+        }
+      end
+      let(:ip) { '1.1.1.1' }
+      let(:ip_id) { '123' }
+
+      let(:network_response) do
+        double(body: { 'floatingips' => [{ 'id' => ip_id }] })
+      end
+
+      let(:network) do
+        s = double('network')
+        expect(s).to receive(:list_floating_ips).with(floating_ip_address: ip).and_return(network_response) # rubocop:disable Metrics/LineLength
+        expect(s).to receive(:delete_floating_ip).with(ip_id)
+        s
+      end
+
+      let(:driver) do
+        d = super()
+        allow(d).to receive(:get_ip).and_return(ip)
+        allow(d).to receive(:compute).and_return(compute)
+        allow(d).to receive(:network).and_return(network)
+        d
+      end
+      it 'deallocates the ip' do
+        driver.destroy(state)
+      end
+    end
   end
 
   describe '#openstack_server' do
@@ -770,6 +803,29 @@ describe Kitchen::Driver::Openstack do
         expect { driver.send(:attach_ip_from_pool, server, pool) }.to \
           raise_error(Kitchen::ActionFailed)
       end
+    end
+  end
+
+  describe '#allocate_ip_from_pool' do
+    let(:server) { nil }
+    let(:pool) { 'swimmers' }
+    let(:config) { { allocate_floating_ip: true } }
+    let(:ip) { '1.1.1.1' }
+    let(:address) do
+      double(ip: ip, fixed_ip: nil, instance_id: nil, pool: pool)
+    end
+    let(:network_response) do
+      double(body: { 'floatingip' => { 'floating_ip_address' => ip } })
+    end
+    let(:network) { double(create_floating_ip: network_response) }
+
+    before(:each) do
+      allow(driver).to receive(:attach_ip).with(server, ip).and_return('bing!')
+      allow(driver).to receive(:network).and_return(network)
+    end
+
+    it 'determines an IP to attempt to attach' do
+      expect(driver.send(:attach_ip_from_pool, server, pool)).to eq('bing!')
     end
   end
 


### PR DESCRIPTION
Build on the work of Fodoj, but add a new flag to maintain backwards compatibility