### PR TITLE
Expose excon timeout configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,13 @@ connections you want declare this.
 ### glance\_cache\_wait\_timeout
 When OpenStack downloads the image into cache, it takes extra time to provision.  Timeout controls maximum amount of time to wait for machine to move from the Build/Spawn phase to Active.
 
+### connect\_timeout
+Connect timeout controls maximum amount of time to wait for machine to respond to ssh login request.
+
+### read\_timeout
+### write\_timeout
+Expose read/write timeout parameters passed down to HTTP connection created via [excon](https://github.com/excon/excon). Default timeouts (from excon) are 60 seconds.
+
 ### server\_wait
 
 `server_wait` is a workaround to deal with how some VMs with `cloud-init`.
@@ -353,6 +360,9 @@ driver:
   image_ref: [SERVER IMAGE ID]
   flavor_ref: [SERVER FLAVOR ID]
   key_name: [KEY NAME]
+  read_timeout: 180
+  write_timeout: 180
+  connect_timeout: 180
 
 transport:
   ssh_key: /path/to/id_rsa #Path to private key that matches the above openstack key_name

--- a/lib/kitchen/driver/openstack.rb
+++ b/lib/kitchen/driver/openstack.rb
@@ -27,6 +27,7 @@ require_relative 'openstack/volume'
 module Kitchen
   module Driver
     # This takes from the Base Class and creates the OpenStack driver.
+    # rubocop: disable Metrics/ClassLength
     class Openstack < Kitchen::Driver::Base
       @@ip_pool_lock = Mutex.new
 
@@ -61,13 +62,11 @@ module Kitchen
       def config_server_name
         return if config[:server_name]
 
-        if config[:server_name_prefix]
-          config[:server_name] = server_name_prefix(
-            config[:server_name_prefix]
-          )
-        else
-          config[:server_name] = default_name
-        end
+        config[:server_name] = if config[:server_name_prefix]
+                                 server_name_prefix(config[:server_name_prefix])
+                               else
+                                 default_name
+                               end
       end
 
       def create(state)

--- a/lib/kitchen/driver/openstack.rb
+++ b/lib/kitchen/driver/openstack.rb
@@ -53,6 +53,9 @@ module Kitchen
       default_config :no_ssh_tcp_check_sleep, 120
       default_config :glance_cache_wait_timeout, 600
       default_config :block_device_mapping, nil
+      default_config :connect_timeout, 60
+      default_config :read_timeout, 60
+      default_config :write_timeout, 60
 
       # Set the proper server name in the config
       def config_server_name
@@ -112,10 +115,12 @@ module Kitchen
 
       def openstack_server
         server_def = {
-          provider: 'OpenStack'
+          provider: 'OpenStack',
+          connection_options: {}
         }
         required_server_settings.each { |s| server_def[s] = config[s] }
         optional_server_settings.each { |s| server_def[s] = config[s] if config[s] } # rubocop:disable Metrics/LineLength
+        connection_options.each { |s| server_def[:connection_options][s] = config[s] if config[s] } # rubocop:disable Metrics/LineLength
         server_def
       end
 
@@ -127,6 +132,10 @@ module Kitchen
         Fog::Compute::OpenStack.recognized.select do |k|
           k.to_s.start_with?('openstack')
         end - required_server_settings
+      end
+
+      def connection_options
+        [:read_timeout, :write_timeout, :connect_timeout]
       end
 
       def network

--- a/spec/kitchen/driver/openstack/volume_spec.rb
+++ b/spec/kitchen/driver/openstack/volume_spec.rb
@@ -9,6 +9,7 @@ require 'rspec'
 require 'kitchen'
 require 'ohai'
 
+# rubocop: disable Metrics/BlockLength
 describe Kitchen::Driver::Openstack::Volume do
   let(:os) do
     {

--- a/spec/kitchen/driver/openstack_spec.rb
+++ b/spec/kitchen/driver/openstack_spec.rb
@@ -57,6 +57,18 @@ describe Kitchen::Driver::Openstack do
         expect(driver[:no_ssh_tcp_check_sleep]).to eq(120)
       end
 
+      it 'sets a default Openstack API read timeout' do
+        expect(driver[:read_timeout]).to eq(60)
+      end
+
+      it 'sets a default Openstack API write timeout' do
+        expect(driver[:write_timeout]).to eq(60)
+      end
+
+      it 'sets a default ssh connection timeout' do
+        expect(driver[:connect_timeout]).to eq(60)
+      end
+
       nils = [
         :server_name,
         :openstack_tenant,
@@ -92,6 +104,9 @@ describe Kitchen::Driver::Openstack do
           floating_ip: '11111',
           network_ref: '0xCAFFE',
           use_ssh_agent: true,
+          connect_timeout: 123,
+          read_timeout: 234,
+          write_timeout: 345,
           block_device_mapping: {
             make_volume: true,
             snapshot_id: '44',
@@ -261,7 +276,13 @@ describe Kitchen::Driver::Openstack do
         openstack_auth_url: 'http://',
         openstack_tenant: 'me',
         openstack_region: 'ORD',
-        openstack_service_name: 'stack'
+        openstack_service_name: 'stack',
+        connection_options:
+          {
+            read_timeout: 60,
+            write_timeout: 60,
+            connect_timeout: 60
+          }
       }
     end
 
@@ -297,7 +318,13 @@ describe Kitchen::Driver::Openstack do
         openstack_auth_url: 'http:',
         openstack_tenant: 'link',
         openstack_region: 'ord',
-        openstack_service_name: 'the_service'
+        openstack_service_name: 'the_service',
+        connection_options:
+          {
+            read_timeout: 60,
+            write_timeout: 60,
+            connect_timeout: 60
+          }
       }
     end
 

--- a/spec/kitchen/driver/openstack_spec.rb
+++ b/spec/kitchen/driver/openstack_spec.rb
@@ -15,6 +15,7 @@ require 'ohai'
 require 'excon'
 require 'fog'
 
+# rubocop: disable Metrics/BlockLength
 describe Kitchen::Driver::Openstack do
   let(:logged_output) { StringIO.new }
   let(:logger) { Logger.new(logged_output) }


### PR DESCRIPTION
Allow excon timeout configuration from .kitchen.yml for usage in unreliable/high latency networks.
Fixing issue #157 