### PR TITLE
Uuids

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,11 +87,23 @@ All of Fog's `openstack` options (`openstack_domain_name`, `openstack_project_na
 
 ### image\_ref
 
-**Required** Server Image ID.
+**image_ref or image_id required** Server Image Name or ID.
+
+### image\_id
+
+**image_ref or image_id required** Server Image ID.  Specifying the ID instead of reference results in a faster create time.
+
+**Note** If the image UUID changes this value will need to be updated. 
 
 ### flavor\_ref
 
-**Required** Server Flavor ID.
+**flavor_ref or flavor_id required** Server Flavor Name or ID.
+
+### flavor\_ref
+
+**flavor_ref or flavor_id required** Server Flavor ID.  Specifying the ID instead of reference results in a faster create time.
+
+**Note** If the flavor UUID changes this value will need to be updated.
 
 ### server\_name
 
@@ -190,12 +202,24 @@ If your vms require config drive.
 
 ### network\_ref
 
-**Deprecated** A list of network names or ids to create instances with.
+**Deprecated** A list of network names to create instances with.
 
 ```yaml
 network_ref:
-   - [OPENSTACK NETWORK NAMES OR...]
-   - [...ID TO CREATE INSTANCE WITH]
+   - [OPENSTACK NETWORK NAMES]
+   - [CREATE INSTANCE WITH]
+```
+
+### network\_id
+
+A list of network ids to create instances with.  Specifying the id instead of reference results in a faster create time.
+
+**Note** If the network UUID changes this value will need to be updated. 
+
+```yaml
+network_ref:
+   - [OPENSTACK NETWORK UUIDs]
+   - [TO CREATE INSTANCE WITH]
 ```
 
 ### no\_ssh\_tcp\_check

--- a/lib/kitchen/driver/openstack.rb
+++ b/lib/kitchen/driver/openstack.rb
@@ -324,6 +324,7 @@ module Kitchen
         [pub, priv]
       end
 
+      # rubocop:disable AbcSize
       def get_ip(server)
         if config[:floating_ip]
           debug "Using floating ip: #{config[:floating_ip]}"

--- a/lib/kitchen/driver/openstack.rb
+++ b/lib/kitchen/driver/openstack.rb
@@ -151,7 +151,7 @@ module Kitchen
         fail(ActionFailed, 'Cannot specify both network_ref and network_id') if config[:network_id] && config[:network_ref] # rubocop:disable Metrics/LineLength, SignalException
         if config[:network_id]
           networks = [].concat([config[:network_id]])
-          server_def[:nics] = networks.flat_map do |net_id|
+          server_def[:nics] = networks.flatten.map do |net_id|
             { 'net_id' => net_id }
           end
         elsif config[:network_ref]

--- a/lib/kitchen/driver/openstack_version.rb
+++ b/lib/kitchen/driver/openstack_version.rb
@@ -22,6 +22,6 @@ module Kitchen
   #
   # @author Jonathan Hartman <j@p4nt5.com>
   module Driver
-    OPENSTACK_VERSION = '3.1.0'.freeze
+    OPENSTACK_VERSION = '3.2.0'.freeze
   end
 end

--- a/spec/kitchen/driver/openstack/volume_spec.rb
+++ b/spec/kitchen/driver/openstack/volume_spec.rb
@@ -9,7 +9,6 @@ require 'rspec'
 require 'kitchen'
 require 'ohai'
 
-# rubocop: disable Metrics/BlockLength
 describe Kitchen::Driver::Openstack::Volume do
   let(:os) do
     {

--- a/spec/kitchen/driver/openstack_spec.rb
+++ b/spec/kitchen/driver/openstack_spec.rb
@@ -15,7 +15,6 @@ require 'ohai'
 require 'excon'
 require 'fog'
 
-# rubocop: disable Metrics/BlockLength
 describe Kitchen::Driver::Openstack do
   let(:logged_output) { StringIO.new }
   let(:logger) { Logger.new(logged_output) }
@@ -537,7 +536,8 @@ describe Kitchen::Driver::Openstack do
           name: 'hello',
           image_ref: '1e1f4346-e3ea-48ba-9d1b-0002bfcb8981',
           flavor_ref: '1',
-          availability_zone: nil)
+          availability_zone: nil
+        )
         driver.send(:create_server)
       end
     end
@@ -572,7 +572,8 @@ describe Kitchen::Driver::Openstack do
           name: 'hello',
           flavor_ref: '1e1f4346-e3ea-48ba-9d1b-0002bfcb8981',
           image_ref: '111',
-          availability_zone: nil)
+          availability_zone: nil
+        )
         driver.send(:create_server)
       end
     end
@@ -662,13 +663,11 @@ describe Kitchen::Driver::Openstack do
         networks = [
           { 'net_id' => '0922b7aa-0a2f-4e68-8ff7-2886c4fc472d' }
         ]
-        expect(servers).to receive(:create).with(
-          name: 'hello',
-          image_ref: '111',
-          flavor_ref: '1',
-          availability_zone: nil,
-          nics: networks
-        )
+        expect(servers).to receive(:create).with(name: 'hello',
+                                                 image_ref: '111',
+                                                 flavor_ref: '1',
+                                                 availability_zone: nil,
+                                                 nics: networks)
         driver.send(:create_server)
       end
     end

--- a/spec/kitchen/driver/openstack_spec.rb
+++ b/spec/kitchen/driver/openstack_spec.rb
@@ -79,7 +79,9 @@ describe Kitchen::Driver::Openstack do
       let(:config) do
         {
           image_ref: '22',
+          image_id: '4391b03e-f7fb-46fd-a356-fa5e42f6d728',
           flavor_ref: '33',
+          flavor_id: '19a2281e-591e-4b47-be06-631c3c7704e8',
           public_key_path: '/tmp',
           username: 'admin',
           port: '2222',
@@ -91,6 +93,7 @@ describe Kitchen::Driver::Openstack do
           floating_ip_pool: 'swimmers',
           floating_ip: '11111',
           network_ref: '0xCAFFE',
+          network_id: '57d6e41a-f369-4c92-9ebe-1fbf198bc783',
           use_ssh_agent: true,
           block_device_mapping: {
             make_volume: true,
@@ -459,6 +462,76 @@ describe Kitchen::Driver::Openstack do
       end
     end
 
+    context 'image_id specified' do
+      let(:config) do
+        {
+          server_name: 'hello',
+          image_id: '1e1f4346-e3ea-48ba-9d1b-0002bfcb8981',
+          flavor_ref: '1'
+        }
+      end
+
+      it 'exact id match' do
+        expect(servers).to receive(:create).with(
+          name: 'hello',
+          image_ref: '1e1f4346-e3ea-48ba-9d1b-0002bfcb8981',
+          flavor_ref: '1',
+          availability_zone: nil)
+        driver.send(:create_server)
+      end
+    end
+
+    context 'image_id and image_ref specified' do
+      let(:config) do
+        {
+          server_name: 'hello',
+          image_id: '1e1f4346-e3ea-48ba-9d1b-0002bfcb8981',
+          image_ref: '111',
+          flavor_ref: '1'
+        }
+      end
+
+      it 'raises an exception' do
+        expect { driver.send(:create_server) }.to \
+          raise_error(Kitchen::ActionFailed)
+      end
+    end
+
+    context 'flavor_id specified' do
+      let(:config) do
+        {
+          server_name: 'hello',
+          flavor_id: '1e1f4346-e3ea-48ba-9d1b-0002bfcb8981',
+          image_ref: '111'
+        }
+      end
+
+      it 'exact id match' do
+        expect(servers).to receive(:create).with(
+          name: 'hello',
+          flavor_ref: '1e1f4346-e3ea-48ba-9d1b-0002bfcb8981',
+          image_ref: '111',
+          availability_zone: nil)
+        driver.send(:create_server)
+      end
+    end
+
+    context 'flavor_id and flavor_ref specified' do
+      let(:config) do
+        {
+          server_name: 'hello',
+          image_id: '1e1f4346-e3ea-48ba-9d1b-0002bfcb8981',
+          flavor_id: '1e1f4346-e3ea-48ba-9d1b-0002bfcb8981',
+          flavor_ref: '1'
+        }
+      end
+
+      it 'raises an exception' do
+        expect { driver.send(:create_server) }.to \
+          raise_error(Kitchen::ActionFailed)
+      end
+    end
+
     context 'image/flavor specifies id' do
       let(:config) do
         {
@@ -511,6 +584,48 @@ describe Kitchen::Driver::Openstack do
                                                  flavor_ref: '1',
                                                  availability_zone: nil)
         driver.send(:create_server)
+      end
+    end
+
+    context 'network specifies network_id' do
+      let(:config) do
+        {
+          server_name: 'hello',
+          image_ref: '111',
+          flavor_ref: '1',
+          network_id: '0922b7aa-0a2f-4e68-8ff7-2886c4fc472d'
+        }
+      end
+
+      it 'exact id match' do
+        networks = [
+          { 'net_id' => '0922b7aa-0a2f-4e68-8ff7-2886c4fc472d' }
+        ]
+        expect(servers).to receive(:create).with(
+          name: 'hello',
+          image_ref: '111',
+          flavor_ref: '1',
+          availability_zone: nil,
+          nics: networks
+        )
+        driver.send(:create_server)
+      end
+    end
+
+    context 'network_id and network_ref specified' do
+      let(:config) do
+        {
+          server_name: 'hello',
+          image_id: '1e1f4346-e3ea-48ba-9d1b-0002bfcb8981',
+          flavor_id: '1e1f4346-e3ea-48ba-9d1b-0002bfcb8981',
+          network_id: '0922b7aa-0a2f-4e68-8ff7-2886c4fc472d',
+          network_ref: '1'
+        }
+      end
+
+      it 'raises an exception' do
+        expect { driver.send(:create_server) }.to \
+          raise_error(Kitchen::ActionFailed)
       end
     end
 


### PR DESCRIPTION
This PR is an optimization that enables the end user to specify the UUIDs of network, image and flavor.  

The calls to lookup these elements consume up to 7 seconds if the openstack box is located remotely.  Making this change reduced the total time before a create is called in openstack from 9 seconds to 2 seconds.

More details on motivation and testing are available [here](http://infrastructuredevops.com/01-18-2017/bluebox-optimize-create.html)


