### PR TITLE
Add metadata support

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -15,4 +15,4 @@ end
 
 RSpec::Core::RakeTask.new(:spec)
 
-task default: [:rubocop, :loc, :spec]
+task default: %i[rubocop loc spec]

--- a/lib/kitchen/driver/openstack.rb
+++ b/lib/kitchen/driver/openstack.rb
@@ -60,6 +60,7 @@ module Kitchen
       default_config :connect_timeout, 60
       default_config :read_timeout, 60
       default_config :write_timeout, 60
+      default_config :metadata, nil
 
       # Set the proper server name in the config
       def config_server_name
@@ -196,6 +197,7 @@ module Kitchen
           key_name
           user_data
           config_drive
+          metadata
         ].each do |c|
           server_def[c] = optional_config(c) if config[c]
         end

--- a/lib/kitchen/driver/openstack.rb
+++ b/lib/kitchen/driver/openstack.rb
@@ -401,7 +401,7 @@ module Kitchen
       end
 
       def hints_path
-        Ohai::Config[:hints_path][0]
+        Ohai.config[:hints_path][0]
       end
 
       def disable_ssl_validation

--- a/lib/kitchen/driver/openstack.rb
+++ b/lib/kitchen/driver/openstack.rb
@@ -1,4 +1,5 @@
 # Encoding: UTF-8
+
 #
 # Author:: Jonathan Hartman (<j@p4nt5.com>)
 # Author:: JJ Asghar (<jj@chef.io>)
@@ -142,7 +143,7 @@ module Kitchen
       end
 
       def required_server_settings
-        [:openstack_username, :openstack_api_key, :openstack_auth_url]
+        %i[openstack_username openstack_api_key openstack_auth_url]
       end
 
       def optional_server_settings
@@ -152,7 +153,7 @@ module Kitchen
       end
 
       def connection_options
-        [:read_timeout, :write_timeout, :connect_timeout]
+        %i[read_timeout write_timeout connect_timeout]
       end
 
       def network
@@ -190,11 +191,11 @@ module Kitchen
           server_def[:block_device_mapping] = get_bdm(config)
         end
 
-        [
-          :security_groups,
-          :key_name,
-          :user_data,
-          :config_drive
+        %i[
+          security_groups
+          key_name
+          user_data
+          config_drive
         ].each do |c|
           server_def[c] = optional_config(c) if config[c]
         end

--- a/lib/kitchen/driver/openstack/volume.rb
+++ b/lib/kitchen/driver/openstack/volume.rb
@@ -1,4 +1,5 @@
 # Encoding: UTF-8
+
 #
 # Author:: Jonathan Hartman (<j@p4nt5.com>)
 #
@@ -40,8 +41,8 @@ module Kitchen
         def create_volume(config, os)
           opt = {}
           bdm = config[:block_device_mapping]
-          vanilla_options = [:snapshot_id, :imageRef, :volume_type,
-                             :source_volid, :availability_zone]
+          vanilla_options = %i[snapshot_id imageRef volume_type
+                               source_volid availability_zone]
           vanilla_options.select { |o| bdm[o] }.each do |key|
             opt[key] = bdm[key]
           end

--- a/lib/kitchen/driver/openstack_version.rb
+++ b/lib/kitchen/driver/openstack_version.rb
@@ -1,4 +1,5 @@
 # Encoding: UTF-8
+
 #
 # Author:: Jonathan Hartman (<j@p4nt5.com>)
 #

--- a/spec/kitchen/driver/openstack_spec.rb
+++ b/spec/kitchen/driver/openstack_spec.rb
@@ -79,6 +79,7 @@ describe Kitchen::Driver::Openstack do
         availability_zone
         security_groups
         network_ref
+        metadata
       ]
       nils.each do |i|
         it "defaults to no #{i}" do
@@ -117,6 +118,10 @@ describe Kitchen::Driver::Openstack do
             volume_size: '5',
             device_name: 'vda',
             delete_on_termination: true
+          },
+          metadata: {
+            name: 'test',
+            ohai: 'chef'
           }
         }
       end
@@ -810,6 +815,37 @@ describe Kitchen::Driver::Openstack do
           flavor_ref: '1',
           availability_zone: nil,
           config_drive: true
+        )
+        driver.send(:create_server)
+      end
+    end
+
+    context 'metadata specified' do
+      let(:config) do
+        {
+          server_name: 'hello',
+          image_ref: '111',
+          flavor_ref: '1',
+          metadata: {
+            name: 'hello',
+            ohai: 'chef'
+          }
+        }
+      end
+      let(:data) do
+        {
+          name: 'hello',
+          ohai: 'chef'
+        }
+      end
+
+      it 'passes metadata contents' do
+        expect(servers).to receive(:create).with(
+          name: 'hello',
+          image_ref: '111',
+          flavor_ref: '1',
+          availability_zone: nil,
+          metadata: data
         )
         driver.send(:create_server)
       end

--- a/spec/kitchen/driver/openstack_spec.rb
+++ b/spec/kitchen/driver/openstack_spec.rb
@@ -18,8 +18,8 @@ require 'fog'
 describe Kitchen::Driver::Openstack do
   let(:logged_output) { StringIO.new }
   let(:logger) { Logger.new(logged_output) }
-  let(:config) { Hash.new }
-  let(:state) { Hash.new }
+  let(:config) { {} }
+  let(:state) { {} }
   let(:instance_name) { 'potatoes' }
   let(:transport)     { Kitchen::Transport::Dummy.new }
   let(:platform)      { Kitchen::Platform.new(name: 'fake_platform') }
@@ -69,16 +69,16 @@ describe Kitchen::Driver::Openstack do
         expect(driver[:connect_timeout]).to eq(60)
       end
 
-      nils = [
-        :server_name,
-        :openstack_tenant,
-        :openstack_region,
-        :openstack_service_name,
-        :floating_ip_pool,
-        :floating_ip,
-        :availability_zone,
-        :security_groups,
-        :network_ref
+      nils = %i[
+        server_name
+        openstack_tenant
+        openstack_region
+        openstack_service_name
+        floating_ip_pool
+        floating_ip
+        availability_zone
+        security_groups
+        network_ref
       ]
       nils.each do |i|
         it "defaults to no #{i}" do
@@ -136,7 +136,7 @@ describe Kitchen::Driver::Openstack do
 
   describe '#create' do
     let(:server) do
-      double(id: 'test123', wait_for: true, public_ip_addresses: %w(1.2.3.4))
+      double(id: 'test123', wait_for: true, public_ip_addresses: %w[1.2.3.4])
     end
     let(:driver) do
       d = super()
@@ -173,7 +173,7 @@ describe Kitchen::Driver::Openstack do
         }
       end
       let(:server) do
-        double(id: 'test123', wait_for: true, public_ip_addresses: %w(1.2.3.4))
+        double(id: 'test123', wait_for: true, public_ip_addresses: %w[1.2.3.4])
       end
 
       let(:driver) do
@@ -232,7 +232,7 @@ describe Kitchen::Driver::Openstack do
     end
 
     context 'no server ID present' do
-      let(:state) { Hash.new }
+      let(:state) { {} }
 
       it 'does nothing' do
         allow(driver).to receive(:compute)
@@ -330,8 +330,8 @@ describe Kitchen::Driver::Openstack do
 
   describe '#required_server_settings' do
     it 'returns the required settings for an OpenStack server' do
-      expected = [
-        :openstack_username, :openstack_api_key, :openstack_auth_url
+      expected = %i[
+        openstack_username openstack_api_key openstack_auth_url
       ]
       expect(driver.send(:required_server_settings)).to eq(expected)
     end
@@ -339,8 +339,8 @@ describe Kitchen::Driver::Openstack do
 
   describe '#optional_server_settings' do
     it 'returns the optional settings for an OpenStack server' do
-      excluded = [
-        :openstack_username, :openstack_api_key, :openstack_auth_url
+      excluded = %i[
+        openstack_username openstack_api_key openstack_auth_url
       ]
       expect(driver.send(:optional_server_settings)).not_to include(*excluded)
     end
@@ -745,7 +745,7 @@ describe Kitchen::Driver::Openstack do
           server_name: 'hello',
           image_ref: '111',
           flavor_ref: '1',
-          network_ref: %w(1 2)
+          network_ref: %w[1 2]
         }
       end
 
@@ -1010,9 +1010,9 @@ describe Kitchen::Driver::Openstack do
     end
 
     context 'both public and private IPs' do
-      let(:public_ip_addresses) { %w(1::1 1.2.3.4) }
-      let(:private_ip_addresses) { %w(5.5.5.5) }
-      let(:parsed_ips) { [%w(1.2.3.4), %w(5.5.5.5)] }
+      let(:public_ip_addresses) { %w[1::1 1.2.3.4] }
+      let(:private_ip_addresses) { %w[5.5.5.5] }
+      let(:parsed_ips) { [%w[1.2.3.4], %w[5.5.5.5]] }
 
       it 'returns a public IPv4 address' do
         expect(driver.send(:get_ip, server)).to eq('1.2.3.4')
@@ -1020,8 +1020,8 @@ describe Kitchen::Driver::Openstack do
     end
 
     context 'only public IPs' do
-      let(:public_ip_addresses) { %w(4.3.2.1 2::1) }
-      let(:parsed_ips) { [%w(4.3.2.1), []] }
+      let(:public_ip_addresses) { %w[4.3.2.1 2::1] }
+      let(:parsed_ips) { [%w[4.3.2.1], []] }
 
       it 'returns a public IPv4 address' do
         expect(driver.send(:get_ip, server)).to eq('4.3.2.1')
@@ -1029,8 +1029,8 @@ describe Kitchen::Driver::Openstack do
     end
 
     context 'only private IPs' do
-      let(:private_ip_addresses) { %w(3::1 5.5.5.5) }
-      let(:parsed_ips) { [[], %w(5.5.5.5)] }
+      let(:private_ip_addresses) { %w[3::1 5.5.5.5] }
+      let(:parsed_ips) { [[], %w[5.5.5.5]] }
 
       it 'returns a private IPv4 address' do
         expect(driver.send(:get_ip, server)).to eq('5.5.5.5')
@@ -1038,8 +1038,8 @@ describe Kitchen::Driver::Openstack do
     end
 
     context 'no predictable network name' do
-      let(:ip_addresses) { %w(3::1 5.5.5.5) }
-      let(:parsed_ips) { [[], %w(5.5.5.5)] }
+      let(:ip_addresses) { %w[3::1 5.5.5.5] }
+      let(:parsed_ips) { [[], %w[5.5.5.5]] }
 
       it 'returns the first IP that matches the IP version' do
         expect(driver.send(:get_ip, server)).to eq('5.5.5.5')
@@ -1090,7 +1090,7 @@ describe Kitchen::Driver::Openstack do
             'private' => [{ 'addr' => '8.8.8.8' }, { 'addr' => '9.9.9.9' }]
           }
         end
-        let(:parsed_ips) { [%w(6.6.6.6 7.7.7.7), %w(8.8.8.8 9.9.9.9)] }
+        let(:parsed_ips) { [%w[6.6.6.6 7.7.7.7], %w[8.8.8.8 9.9.9.9]] }
 
         it 'selects the first public IP' do
           expect(driver.send(:get_ip, server)).to eq('6.6.6.6')
@@ -1149,7 +1149,7 @@ describe Kitchen::Driver::Openstack do
         let(:addresses) do
           { 'public' => [{ 'addr' => '6.6.6.6' }, { 'addr' => '7.7.7.7' }] }
         end
-        let(:parsed_ips) { [%w(6.6.6.6 7.7.7.7), []] }
+        let(:parsed_ips) { [%w[6.6.6.6 7.7.7.7], []] }
 
         it 'selects the first public IP' do
           expect(driver.send(:get_ip, server)).to eq('6.6.6.6')
@@ -1160,7 +1160,7 @@ describe Kitchen::Driver::Openstack do
         let(:addresses) do
           { 'private' => [{ 'addr' => '8.8.8.8' }, { 'addr' => '9.9.9.9' }] }
         end
-        let(:parsed_ips) { [[], %w(8.8.8.8 9.9.9.9)] }
+        let(:parsed_ips) { [[], %w[8.8.8.8 9.9.9.9]] }
 
         it 'selects the first private IP' do
           expect(driver.send(:get_ip, server)).to eq('8.8.8.8')
@@ -1188,10 +1188,10 @@ describe Kitchen::Driver::Openstack do
   end
 
   describe '#parse_ips' do
-    let(:pub_v4) { %w(1.1.1.1 2.2.2.2) }
-    let(:pub_v6) { %w(1::1 2::2) }
-    let(:priv_v4) { %w(3.3.3.3 4.4.4.4) }
-    let(:priv_v6) { %w(3::3 4::4) }
+    let(:pub_v4) { %w[1.1.1.1 2.2.2.2] }
+    let(:pub_v6) { %w[1::1 2::2] }
+    let(:priv_v4) { %w[3.3.3.3 4.4.4.4] }
+    let(:priv_v6) { %w[3::3 4::4] }
     let(:pub) { pub_v4 + pub_v6 }
     let(:priv) { priv_v4 + priv_v6 }
 


### PR DESCRIPTION
This patch adds `metadata` support to kitchen-openstack.

Note:
The branch is created from one in #165 because the master is failing.
Please review and merge #165 first and I will rebase onto the updated master to make history clean.