### PR TITLE
Support for v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ driver:
   openstack_username: [YOUR OPENSTACK USERNAME]
   openstack_api_key: [YOUR OPENSTACK API KEY] # AKA your OpenStack Password
   openstack_auth_url: [YOUR OPENSTACK AUTH URL] # if you are using v3, API_URL/v3/auth/tokens
+  openstack_domain_id: [default is 'default'; otherwise YOUR OPENSTACK DOMAIN ID]
   require_chef_omnibus: [e.g. 'true' or a version number if you need Chef]
   image_ref: [SERVER IMAGE ID]
   flavor_ref: [SERVER FLAVOR ID]
@@ -387,6 +388,7 @@ driver:
   openstack_username: [YOUR OPENSTACK USERNAME]
   openstack_api_key: [YOUR OPENSTACK API KEY] # AKA your OPENSTACK PASSWORD
   openstack_auth_url: [YOUR OPENSTACK AUTH URL]
+  openstack_domain_id: [default is 'default'; otherwise YOUR OPENSTACK DOMAIN ID]
   require_chef_omnibus: [e.g. 'true' or a version number if you need Chef]
   image_ref: [SERVER IMAGE ID]
   flavor_ref: [SERVER FLAVOR ID]

--- a/lib/kitchen/driver/openstack.rb
+++ b/lib/kitchen/driver/openstack.rb
@@ -143,7 +143,7 @@ module Kitchen
       end
 
       def required_server_settings
-        %i{openstack_username openstack_api_key openstack_auth_url}
+        %i{openstack_username openstack_api_key openstack_auth_url openstack_domain_id}
       end
 
       def optional_server_settings

--- a/lib/kitchen/driver/openstack.rb
+++ b/lib/kitchen/driver/openstack.rb
@@ -39,7 +39,7 @@ module Kitchen
       default_config :key_name, nil
       default_config :port, "22"
       default_config :use_ipv6, false
-      default_config :openstack_tenant, nil
+      default_config :openstack_project_name, nil
       default_config :openstack_region, nil
       default_config :openstack_service_name, nil
       default_config :openstack_network_name, nil

--- a/spec/kitchen/driver/openstack/volume_spec.rb
+++ b/spec/kitchen/driver/openstack/volume_spec.rb
@@ -16,7 +16,7 @@ describe Kitchen::Driver::Openstack::Volume do
       openstack_domain_id: "default",
       openstack_api_key: "sparkle",
       openstack_auth_url: "http:",
-      openstack_tenant: "trixie",
+      openstack_project_name: "trixie",
       openstack_region: "syd",
       openstack_service_name: "the_service",
     }

--- a/spec/kitchen/driver/openstack/volume_spec.rb
+++ b/spec/kitchen/driver/openstack/volume_spec.rb
@@ -13,6 +13,7 @@ describe Kitchen::Driver::Openstack::Volume do
   let(:os) do
     {
       openstack_username: "twilight",
+      openstack_domain_id: "default",
       openstack_api_key: "sparkle",
       openstack_auth_url: "http:",
       openstack_tenant: "trixie",

--- a/spec/kitchen/driver/openstack_spec.rb
+++ b/spec/kitchen/driver/openstack_spec.rb
@@ -71,7 +71,7 @@ describe Kitchen::Driver::Openstack do
 
       nils = %i{
         server_name
-        openstack_tenant
+        openstack_project_name
         openstack_region
         openstack_service_name
         floating_ip_pool
@@ -100,7 +100,7 @@ describe Kitchen::Driver::Openstack do
           port: "2222",
           server_name: "puppy",
           server_name_prefix: "parsnip",
-          openstack_tenant: "that_one",
+          openstack_project_name: "that_one",
           openstack_region: "atlantis",
           openstack_service_name: "the_service",
           floating_ip_pool: "swimmers",
@@ -173,7 +173,7 @@ describe Kitchen::Driver::Openstack do
           openstack_domain_id: "default",
           openstack_api_key: "world",
           openstack_auth_url: "http:",
-          openstack_tenant: "www",
+          openstack_project_name: "www",
           glance_cache_wait_timeout: 600,
           disable_ssl_validation: false,
         }
@@ -317,7 +317,7 @@ describe Kitchen::Driver::Openstack do
         openstack_domain_id: "default",
         openstack_api_key: "b",
         openstack_auth_url: "http://",
-        openstack_tenant: "me",
+        openstack_project_name: "me",
         openstack_region: "ORD",
         openstack_service_name: "stack",
         connection_options:
@@ -360,7 +360,7 @@ describe Kitchen::Driver::Openstack do
         openstack_domain_id: "default",
         openstack_api_key: "potato",
         openstack_auth_url: "http:",
-        openstack_tenant: "link",
+        openstack_project_name: "link",
         openstack_region: "ord",
         openstack_service_name: "the_service",
         connection_options:
@@ -1372,7 +1372,7 @@ describe Kitchen::Driver::Openstack do
         openstack_domain_id: "default",
         openstack_api_key: "b",
         openstack_auth_url: "http://",
-        openstack_tenant: "me",
+        openstack_project_name: "me",
         openstack_region: "ORD",
         openstack_service_name: "stack",
         image_ref: "22",

--- a/spec/kitchen/driver/openstack_spec.rb
+++ b/spec/kitchen/driver/openstack_spec.rb
@@ -170,6 +170,7 @@ describe Kitchen::Driver::Openstack do
       let(:config) do
         {
           openstack_username: "hello",
+          openstack_domain_id: "default",
           openstack_api_key: "world",
           openstack_auth_url: "http:",
           openstack_tenant: "www",
@@ -313,6 +314,7 @@ describe Kitchen::Driver::Openstack do
     let(:config) do
       {
         openstack_username: "a",
+        openstack_domain_id: "default",
         openstack_api_key: "b",
         openstack_auth_url: "http://",
         openstack_tenant: "me",
@@ -336,7 +338,7 @@ describe Kitchen::Driver::Openstack do
   describe "#required_server_settings" do
     it "returns the required settings for an OpenStack server" do
       expected = %i{
-        openstack_username openstack_api_key openstack_auth_url
+        openstack_username openstack_api_key openstack_auth_url openstack_domain_id
       }
       expect(driver.send(:required_server_settings)).to eq(expected)
     end
@@ -345,7 +347,7 @@ describe Kitchen::Driver::Openstack do
   describe "#optional_server_settings" do
     it "returns the optional settings for an OpenStack server" do
       excluded = %i{
-        openstack_username openstack_api_key openstack_auth_url
+        openstack_username openstack_api_key openstack_auth_url openstack_domain_id
       }
       expect(driver.send(:optional_server_settings)).not_to include(*excluded)
     end
@@ -355,6 +357,7 @@ describe Kitchen::Driver::Openstack do
     let(:config) do
       {
         openstack_username: "monkey",
+        openstack_domain_id: "default",
         openstack_api_key: "potato",
         openstack_auth_url: "http:",
         openstack_tenant: "link",
@@ -1366,6 +1369,7 @@ describe Kitchen::Driver::Openstack do
     let(:config) do
       {
         openstack_username: "a",
+        openstack_domain_id: "default",
         openstack_api_key: "b",
         openstack_auth_url: "http://",
         openstack_tenant: "me",


### PR DESCRIPTION
Hi - I modified the plugin to work with identity v3 where the domain_id can be passed in and "tenant" is renamed to "project". Seems to work just fine; I'm provisioning new instances on OpenStack version Pike no problems at all.