### PR TITLE
Fall back on Etc.getlogin for windows environments

### DIFF
--- a/lib/kitchen/driver/openstack.rb
+++ b/lib/kitchen/driver/openstack.rb
@@ -262,7 +262,7 @@ module Kitchen
       def default_name
         [
           instance.name.gsub(/\W/, "")[0..14],
-          (Etc.getpwuid.name || "nologin").gsub(/\W/, "")[0..14],
+          (Etc.getpwuid ? Etc.getpwuid.name : Etc.getlogin || "nologin").gsub(/\W/, "")[0..14],
           Socket.gethostname.gsub(/\W/, "")[0..22],
           Array.new(7) { rand(36).to_s(36) }.join,
         ].join("-")

--- a/lib/kitchen/driver/openstack.rb
+++ b/lib/kitchen/driver/openstack.rb
@@ -262,7 +262,7 @@ module Kitchen
       def default_name
         [
           instance.name.gsub(/\W/, "")[0..14],
-          (Etc.getpwuid ? Etc.getpwuid.name : Etc.getlogin || "nologin").gsub(/\W/, "")[0..14],
+          ((Etc.getpwuid ? Etc.getpwuid.name : Etc.getlogin) || "nologin").gsub(/\W/, "")[0..14],
           Socket.gethostname.gsub(/\W/, "")[0..22],
           Array.new(7) { rand(36).to_s(36) }.join,
         ].join("-")


### PR DESCRIPTION
The recent change in [PR-183](https://github.com/test-kitchen/kitchen-openstack/pull/183) appears to break the usage of the kitchen-openstack driver on Windows environments.

Running `Etc.getpwuid.name`  results in `undefined method 'name' for nil:NilClass (NoMethodError)`  on git-bash (and I presume other Windows setups) due to the lack of an `/etc/passwd` file.

ChefDK version information:

```
chef-client version: 14.4.56
delivery version: master (6862f27aba89109a9630f0b6c6798efec56b4efe)
berks version: 7.0.6
kitchen version: 1.23.2
inspec version: 2.2.70
```
Gem versions:

```
kitchen-openstack (3.6.1)
openstack (3.3.20)
```
Thank you in advance for looking at this PR.