### PR TITLE
Loosen the Test Kitchen dep to allow 2.0

### DIFF
--- a/kitchen-openstack.gemspec
+++ b/kitchen-openstack.gemspec
@@ -13,16 +13,14 @@ Gem::Specification.new do |spec|
   spec.description   = "A Test Kitchen OpenStack Nova driver"
   spec.summary       = spec.description
   spec.homepage      = "https://github.com/test-kitchen/kitchen-openstack"
-  spec.license       = "Apache"
+  spec.license       = "Apache-2.0"
 
   spec.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = ">= 2.0.0"
 
-  spec.add_dependency "test-kitchen", "~> 1.4", ">= 1.4.1"
+  spec.add_dependency "test-kitchen", ">= 1.4.1", "< 3"
   spec.add_dependency "fog-openstack", "~> 0.1"
   spec.add_dependency "unf"
   spec.add_dependency "ohai"


### PR DESCRIPTION
2.0 will have no impact on this gem
Also remove the executable and test_files configs that aren't necessary
and fix the license to be a SPDX compliant string

Signed-off-by: Tim Smith <tsmith@chef.io>