### PR TITLE
Added functionality to delay attaching a volume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## [v3.7.0]
+* Added functionality to delay attaching a volume after its marked active when configuring block device mapping. This addresses an issue in VMWare Openstack (VIO) that may be present in others when attaching large volumes in which VIO would mark the device active but was still performing operations which caused test kitchen to fail.
+
 ## [v3.6.2](https://github.com/test-kitchen/kitchen-openstack/tree/v3.6.2)
 
 [Full Changelog](https://github.com/test-kitchen/kitchen-openstack/compare/v3.6.1...v3.6.2)

--- a/README.md
+++ b/README.md
@@ -285,6 +285,9 @@ Otherwise set this to `false`.
 #### creation\_timeout
 Timeout to wait for volume to become available.  If a large volume is provisioned, it might take time to provision it on the backend.  Maximum amount of time to wait for volume to be created and be available.
 
+#### attach\_timeout
+If using a customized version of Openstack such a VMWare Integrated OPenstack (VIO), it may mark a volume active even though it is still performing some actions which may cause test kitchen to attach the volume to early which results in errors. Specify in seconds the amount of time to delay attaching the volume after its been marked active. Default timeout is 0.
+
 #### Example
 
 ```yaml
@@ -295,6 +298,7 @@ block_device_mapping:
   availability_zone: nova
   delete_on_termination: false
   creation_timeout: 120
+  attach_timeout: 240
 ```
 
 ## Network and Communication Configuration

--- a/lib/kitchen/driver/openstack/volume.rb
+++ b/lib/kitchen/driver/openstack/volume.rb
@@ -74,6 +74,13 @@ module Kitchen
             ready?
           end
 
+          attach_timeout = bdm.key?(:attach_timeout) ? bdm[:attach_timeout] : 0
+
+          if attach_timeout > 0
+            @logger.debug "Sleeping for an additional #{attach_timeout} seconds before attaching volume to wait for Openstack to finish disk creation process.."
+            sleep(attach_timeout)
+          end
+
           @logger.debug "Volume Ready"
 
           vol_id

--- a/spec/kitchen/driver/openstack/volume_spec.rb
+++ b/spec/kitchen/driver/openstack/volume_spec.rb
@@ -42,7 +42,7 @@ describe Kitchen::Driver::Openstack::Volume do
           snapshot_id: "444",
           volume_size: "5",
           creation_timeout: "30",
-          attach_timeout: 0,
+          attach_timeout: 5,
         },
       }
     end
@@ -108,7 +108,7 @@ describe Kitchen::Driver::Openstack::Volume do
           volume_size: "5",
           volume_device_name: "vda",
           delete_on_termination: true,
-          attach_timeout: 0,
+          attach_timeout: 5,
         },
       }
     end

--- a/spec/kitchen/driver/openstack/volume_spec.rb
+++ b/spec/kitchen/driver/openstack/volume_spec.rb
@@ -89,6 +89,7 @@ describe Kitchen::Driver::Openstack::Volume do
       # This makes rspec work
       # but the vol_driver doesnt have these methods properties?
       allow(vol_driver).to receive(:status).and_return("ACTIVE")
+      allow(config).to receive(:attach_timeout).and_return(5)
       allow(vol_driver).to receive(:ready?).and_return(true)
       allow(volume_model).to receive(:wait_for)
         .with(an_instance_of(String)).and_yield

--- a/spec/kitchen/driver/openstack/volume_spec.rb
+++ b/spec/kitchen/driver/openstack/volume_spec.rb
@@ -42,7 +42,7 @@ describe Kitchen::Driver::Openstack::Volume do
           snapshot_id: "444",
           volume_size: "5",
           creation_timeout: "30",
-          attach_timeout: 0
+          attach_timeout: 0,
         },
       }
     end

--- a/spec/kitchen/driver/openstack/volume_spec.rb
+++ b/spec/kitchen/driver/openstack/volume_spec.rb
@@ -42,6 +42,7 @@ describe Kitchen::Driver::Openstack::Volume do
           snapshot_id: "444",
           volume_size: "5",
           creation_timeout: "30",
+          attach_timeout: 0
         },
       }
     end
@@ -107,6 +108,7 @@ describe Kitchen::Driver::Openstack::Volume do
           volume_size: "5",
           volume_device_name: "vda",
           delete_on_termination: true,
+          attach_timeout: 0,
         },
       }
     end

--- a/spec/kitchen/driver/openstack_spec.rb
+++ b/spec/kitchen/driver/openstack_spec.rb
@@ -156,7 +156,6 @@ describe Kitchen::Driver::Openstack do
       allow(d).to receive(:sleep)
       allow(d).to receive(:wait_for_ssh_key_access).and_return("SSH key authetication successful") # rubocop:disable Metrics/LineLength
       allow(d).to receive(:disable_ssl_validation).and_return(false)
-      allow(d).to receive(:ready?).and_return(true)
       d
     end
 
@@ -208,6 +207,10 @@ describe Kitchen::Driver::Openstack do
       it "throws an Action error when trying to create_server" do
         allow(driver).to receive(:create_server).and_raise(Fog::Errors::Error)
         expect { driver.send(:create, state) }.to raise_error(Kitchen::ActionFailed) # rubocop:disable Metrics/LineLength
+      end
+
+      it 'returns ready status' do
+        expect(driver.send(:ready?, state)).to be true
       end
     end
   end

--- a/spec/kitchen/driver/openstack_spec.rb
+++ b/spec/kitchen/driver/openstack_spec.rb
@@ -156,6 +156,7 @@ describe Kitchen::Driver::Openstack do
       allow(d).to receive(:sleep)
       allow(d).to receive(:wait_for_ssh_key_access).and_return("SSH key authetication successful") # rubocop:disable Metrics/LineLength
       allow(d).to receive(:disable_ssl_validation).and_return(false)
+      allow(d).to receive(:ready?).and_return(true)
       d
     end
 

--- a/spec/kitchen/driver/openstack_spec.rb
+++ b/spec/kitchen/driver/openstack_spec.rb
@@ -209,7 +209,7 @@ describe Kitchen::Driver::Openstack do
         expect { driver.send(:create, state) }.to raise_error(Kitchen::ActionFailed) # rubocop:disable Metrics/LineLength
       end
 
-      it 'returns ready status' do
+      it "returns ready status" do
         expect(driver.send(:ready?, state)).to be true
       end
     end


### PR DESCRIPTION
Hi,

This change adds new functionality to fix an issue where test kitchen attempts to attach a volume to early. Some customized versions of Openstack such as VMWare Integrated Openstack (VIO) may mark a volume as active while it is still performing operations on large volumes. This causes test kitchen to attach the volume to early which results in errors since its not fully active.

This change now offers the ability to delay attaching the volume for a specified amount of time