### PR TITLE
use config by value instead of reference

### DIFF
--- a/lib/kitchen/driver/openstack/volume.rb
+++ b/lib/kitchen/driver/openstack/volume.rb
@@ -87,7 +87,7 @@ module Kitchen
         end
 
         def get_bdm(config, os)
-          bdm = config[:block_device_mapping]
+          bdm = config[:block_device_mapping].clone
           bdm[:volume_id] = create_volume(config, os) if bdm[:make_volume]
           bdm.delete_if { |k, _| k == :make_volume }
           bdm.delete_if { |k, _| k == :snapshot_id }


### PR DESCRIPTION
If block_device_mapping is using sequental kitchen test cases execution will fail
Reason: during first run config is changing in get_bdm function because it is accessing by reference. So second test case will try to use volume from a first test case instead of creating a new volume. And it even will use those volume in case delete_on_termination is set to false