### PR TITLE
Optimize our requires

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -238,7 +238,7 @@
 
 **Merged pull requests:**
 
-- fixup install ohai hints so the file is written with root privledges [\#104](https://github.com/test-kitchen/kitchen-openstack/pull/104) ([spion06](https://github.com/spion06))
+- fixup install ohai hints so the file is written with root privileges [\#104](https://github.com/test-kitchen/kitchen-openstack/pull/104) ([spion06](https://github.com/spion06))
 - Readd key\_name to README [\#103](https://github.com/test-kitchen/kitchen-openstack/pull/103) ([BobbyRyterski](https://github.com/BobbyRyterski))
 - Add transport ssh\_key note to README [\#102](https://github.com/test-kitchen/kitchen-openstack/pull/102) ([BobbyRyterski](https://github.com/BobbyRyterski))
 

--- a/lib/kitchen/driver/openstack.rb
+++ b/lib/kitchen/driver/openstack.rb
@@ -21,7 +21,7 @@
 
 require "kitchen"
 require "fog/openstack"
-require "ohai"
+require "ohai" unless defined?(Ohai::System)
 require_relative "openstack_version"
 require_relative "openstack/volume"
 
@@ -411,7 +411,7 @@ module Kitchen
       end
 
       def disable_ssl_validation
-        require "excon"
+        require "excon" unless defined?(Excon)
         Excon.defaults[:ssl_verify_peer] = false
       end
 
@@ -441,7 +441,7 @@ module Kitchen
         if name.start_with?("/") && name.end_with?("/")
           regex = Regexp.new(name[1...-1])
           # check for regex name match
-          collection.each { |single| return single if regex =~ single.name }
+          collection.each { |single| return single if regex&.match?(single.name) }
         else
           # check for exact id match
           collection.each { |single| return single if single.id == name }

--- a/spec/kitchen/driver/openstack/volume_spec.rb
+++ b/spec/kitchen/driver/openstack/volume_spec.rb
@@ -4,10 +4,10 @@ require_relative "../../../spec_helper"
 require_relative "../../../../lib/kitchen/driver/openstack/volume"
 
 require "logger"
-require "stringio"
+require "stringio" unless defined?(StringIO)
 require "rspec"
 require "kitchen"
-require "ohai"
+require "ohai" unless defined?(Ohai::System)
 
 describe Kitchen::Driver::Openstack::Volume do
   let(:os) do

--- a/spec/kitchen/driver/openstack_spec.rb
+++ b/spec/kitchen/driver/openstack_spec.rb
@@ -4,15 +4,15 @@ require_relative "../../spec_helper"
 require_relative "../../../lib/kitchen/driver/openstack"
 
 require "logger"
-require "stringio"
+require "stringio" unless defined?(StringIO)
 require "rspec"
 require "kitchen"
 require "kitchen/driver/openstack"
 require "kitchen/provisioner/dummy"
 require "kitchen/transport/dummy"
 require "kitchen/verifier/dummy"
-require "ohai"
-require "excon"
+require "ohai" unless defined?(Ohai::System)
+require "excon" unless defined?(Excon)
 require "fog/openstack"
 
 describe Kitchen::Driver::Openstack do


### PR DESCRIPTION
Avoid requiring things that are already defined. Rubygems is very slow at traversing the filesystem.

Signed-off-by: Tim Smith <tsmith@chef.io>