### PR TITLE
New option cloud_config for generating user data

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '2.4', '2.5', '2.6', '2.7' ]
+        ruby: [ '2.6', '2.7' ]
     name: Lint & Test with Ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ security_groups:
 
 ### user\_data
 
-If your vms have `cloud-init` enabled you can use the `user_data` in your
+If your VMs have `cloud-init` enabled you can use the `user_data` in your
 kitchen.yml to inject commands at boot time.
 
 ```
@@ -196,9 +196,28 @@ for example:
 echo "do whatever you want to pre-configure your machine"
 ```
 
+### cloud\_config
+
+If your VMs have `cloud-init` enabled you can use `cloud_config` to generate userdata for use by cloud-init in the [cloud-config format](https://cloudinit.readthedocs.io/en/latest/topics/format.html#cloud-config-data). This provides a convenient way to specify cloud-init config inline. As the cloud-config format uses YAML the resulting userdata is essentially a copy+paste of `cloud_config` with the header line '#cloud-config'
+
+```
+    driver_config:
+      cloud_config:
+        hostname: my-hostname
+```
+
+This will pass the following user data to OpenStack:
+
+```
+#cloud-config
+hostname: my-hostname
+```
+
+The `cloud_config` and `user_data` options are mutually exclusive.
+
 ### config\_drive
 
-If your vms require config drive.
+If your VMs require config drive.
 
 ```
     config_drive: true

--- a/kitchen-openstack.gemspec
+++ b/kitchen-openstack.gemspec
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-lib = File.expand_path("../lib", __FILE__)
+lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "kitchen/driver/openstack_version"
 
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.files         = Dir["LICENSE", "README.md", "lib/**/*"]
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.0.0"
+  spec.required_ruby_version = ">= 2.6.0"
 
   spec.add_dependency "test-kitchen", ">= 1.4.1", "< 3"
   spec.add_dependency "fog-openstack", "~> 1.0"

--- a/lib/kitchen/driver/openstack.rb
+++ b/lib/kitchen/driver/openstack.rb
@@ -22,6 +22,7 @@
 require "kitchen"
 require "fog/openstack"
 require "ohai" unless defined?(Ohai::System)
+require "yaml"
 require_relative "openstack_version"
 require_relative "openstack/volume"
 
@@ -198,6 +199,11 @@ module Kitchen
           metadata
         }.each do |c|
           server_def[c] = optional_config(c) if config[c]
+        end
+
+        if config[:cloud_config]
+          raise(ActionFailed, "Cannot specify both cloud_config and user_data") if config[:user_data]
+          server_def[:user_data] = Kitchen::Util.stringified_hash(config[:cloud_config]).to_yaml.gsub(/^---\n/, "#cloud-config\n")
         end
 
         # Can't use the Fog bootstrap and/or setup methods here; they require a

--- a/lib/kitchen/driver/openstack.rb
+++ b/lib/kitchen/driver/openstack.rb
@@ -203,6 +203,7 @@ module Kitchen
 
         if config[:cloud_config]
           raise(ActionFailed, "Cannot specify both cloud_config and user_data") if config[:user_data]
+
           server_def[:user_data] = Kitchen::Util.stringified_hash(config[:cloud_config]).to_yaml.gsub(/^---\n/, "#cloud-config\n")
         end
 


### PR DESCRIPTION
# Description

If your VMs have `cloud-init` enabled you can use `cloud_config` to generate userdata for use by cloud-init in the [cloud-config format](https://cloudinit.readthedocs.io/en/latest/topics/format.html#cloud-config-data).

## Reasoning

The existing `user_data` option requires a separate file to be created for specifying user data. For a project with multiple suites this would require a lot of individual files. This new `cloud_config` option enables this content to be included inline in kithen.yml much like how the vagrant driver works.