### PR TITLE
Check for ERROR status after server create

### DIFF
--- a/lib/kitchen/driver/openstack.rb
+++ b/lib/kitchen/driver/openstack.rb
@@ -82,14 +82,16 @@ module Kitchen
         disable_ssl_validation if config[:disable_ssl_validation]
         server = create_server
         state[:server_id] = server.id
-        info "OpenStack instance with ID of <#{state[:server_id]}> is ready."
 
         # this is due to the glance_caching issues. Annoying yes, but necessary.
-        debug "Waiting for VM to be in ACTIVE state for a max time of:#{config[:glance_cache_wait_timeout]} seconds"
+        debug "Waiting for a max time of:#{config[:glance_cache_wait_timeout]} seconds for OpenStack server to be in ACTIVE state"
         server.wait_for(config[:glance_cache_wait_timeout]) do
           sleep(1)
+          raise(Kitchen::InstanceFailure, "OpenStack server ID <#{state[:server_id]}> build failed to ERROR state") if failed?
+
           ready?
         end
+        info "OpenStack server ID <#{state[:server_id]}> created"
 
         if config[:floating_ip]
           attach_ip(server, config[:floating_ip])


### PR DESCRIPTION
# Description

After create_server returns check for an ERROR status and raise an exception. Since the ERROR state is unrecoverable there is no need to wait for glance_cache_wait_timeout to expire.  glance_cache_wait_timeout is usually set to higher values than the other timeouts used with the OpenStack API. In CI scenarios where server create failures are more painful due to volume this change eliminates most of this wait time and allows the CI job to enter its retry logic sooner.

## Issues Resolved

n/a

## Check List

- [ X] All tests pass. See TESTING.md for details.
- [ X] New functionality includes testing.
- [ n/a] New functionality has been documented in the README if applicable.
